### PR TITLE
Replace enums by "as const"

### DIFF
--- a/client/context.ts
+++ b/client/context.ts
@@ -1,7 +1,6 @@
 import {
   type AnyPacket,
   AsyncQueue,
-  type AuthenticationResult,
   type ConnectPacket,
   Deferred,
   logger,
@@ -13,25 +12,29 @@ import {
   type ReturnCodes,
   type SockConn,
   type SubscribePacket,
+  type TAuthenticationResult,
   Timer,
   type UnsubscribePacket,
 } from "./deps.ts";
 
 import { handlePacket } from "./handlers/handlePacket.ts";
 
-export enum ConnectionState {
-  offline = "offline",
-  connecting = "connecting",
-  connected = "connected",
-  disconnecting = "disconnecting",
-  disconnected = "disconnected",
-}
+export const ConnectionState = {
+  offline: "offline",
+  connecting: "connecting",
+  connected: "connected",
+  disconnecting: "disconnecting",
+  disconnected: "disconnected",
+} as const;
+
+export type TConnectionState =
+  typeof ConnectionState[keyof typeof ConnectionState];
 
 export class Context {
   mqttConn?: MqttConn;
-  connectionState: ConnectionState;
+  connectionState: TConnectionState;
   pingTimer?: Timer;
-  unresolvedConnect?: Deferred<AuthenticationResult>;
+  unresolvedConnect?: Deferred<TAuthenticationResult>;
   unresolvedPublish: Map<PacketId, Deferred<void>>;
   unresolvedSubscribe: Map<PacketId, Deferred<ReturnCodes>>;
   unresolvedUnSubscribe: Map<PacketId, Deferred<void>>;

--- a/client/deps.ts
+++ b/client/deps.ts
@@ -14,6 +14,7 @@ export type {
   ReturnCodes,
   SubackPacket,
   SubscribePacket,
+  TAuthenticationResult,
   Topic,
   UnsubackPacket,
   UnsubscribePacket,
@@ -21,8 +22,10 @@ export type {
 
 export {
   AuthenticationResult,
+  AuthenticationResultByNumber,
   decodePayload,
   encode,
+  PacketNameByType,
   PacketType,
 } from "../mqttPacket/mod.ts";
 

--- a/client/handlers/handleConnack.ts
+++ b/client/handlers/handleConnack.ts
@@ -1,5 +1,5 @@
 import { ConnectionState, type Context } from "../context.ts";
-import { AuthenticationResult, type ConnackPacket } from "../deps.ts";
+import { AuthenticationResultByNumber, type ConnackPacket } from "../deps.ts";
 
 export async function handleConnack(packet: ConnackPacket, ctx: Context) {
   if (packet.returnCode === 0) {
@@ -13,7 +13,7 @@ export async function handleConnack(packet: ConnackPacket, ctx: Context) {
     return;
   }
   const err = new Error(
-    `Connect failed: ${AuthenticationResult[packet.returnCode]}`,
+    `Connect failed: ${AuthenticationResultByNumber[packet.returnCode]}`,
   );
   ctx.connectionState = ConnectionState.disconnecting;
   ctx.pingTimer?.clear();

--- a/client/handlers/handlePacket.ts
+++ b/client/handlers/handlePacket.ts
@@ -1,5 +1,4 @@
 import { ConnectionState, type Context } from "../context.ts";
-import { type AnyPacket, PacketType } from "../deps.ts";
 import { handleConnack } from "./handleConnack.ts";
 import { handlePublish } from "./handlePublish.ts";
 import { handlePuback } from "./handlePuback.ts";
@@ -8,7 +7,18 @@ import { handlePubrel } from "./handlePubrel.ts";
 import { handlePubcomp } from "./handlePubcomp.ts";
 import { handleSuback } from "./handleSuback.ts";
 import { handleUnsuback } from "./handleUnsuback.ts";
-import { logger } from "../deps.ts";
+import { logger, PacketNameByType, PacketType } from "../deps.ts";
+import type {
+  AnyPacket,
+  ConnackPacket,
+  PubackPacket,
+  PubcompPacket,
+  PublishPacket,
+  PubrecPacket,
+  PubrelPacket,
+  SubackPacket,
+  UnsubackPacket,
+} from "../deps.ts";
 
 export async function handlePacket(
   ctx: Context,
@@ -17,41 +27,43 @@ export async function handlePacket(
   logger.debug({ received: JSON.stringify(packet, null, 2) });
   if (ctx.connectionState !== ConnectionState.connected) {
     if (packet.type === PacketType.connack) {
-      handleConnack(packet, ctx);
+      handleConnack(packet as ConnackPacket, ctx);
     } else {
       throw new Error(
-        `Received ${PacketType[packet.type]} packet before connect`,
+        `Received ${PacketNameByType[packet.type]} packet before connect`,
       );
     }
   } else {
     switch (packet.type) {
-      case PacketType.pingreq:
+      case PacketType.pingres:
         break;
       case PacketType.publish:
-        await handlePublish(ctx, packet);
+        await handlePublish(ctx, packet as PublishPacket);
         break;
       case PacketType.puback:
-        await handlePuback(ctx, packet);
+        await handlePuback(ctx, packet as PubackPacket);
         break;
       case PacketType.pubrel:
-        await handlePubrel(ctx, packet);
+        await handlePubrel(ctx, packet as PubrelPacket);
         break;
       case PacketType.pubrec:
-        await handlePubrec(ctx, packet);
+        await handlePubrec(ctx, packet as PubrecPacket);
         break;
       case PacketType.pubcomp:
-        await handlePubcomp(ctx, packet);
+        await handlePubcomp(ctx, packet as PubcompPacket);
         break;
       case PacketType.suback:
-        await handleSuback(ctx, packet);
+        await handleSuback(ctx, packet as SubackPacket);
         break;
       case PacketType.unsuback:
-        handleUnsuback(ctx, packet);
+        handleUnsuback(ctx, packet as UnsubackPacket);
         break;
 
       default:
         throw new Error(
-          `Received unexpected ${PacketType[packet.type]} packet after connect`,
+          `Received unexpected ${
+            PacketNameByType[packet.type]
+          } packet after connect`,
         );
     }
   }

--- a/mqttConn/mqttConn.ts
+++ b/mqttConn/mqttConn.ts
@@ -9,11 +9,11 @@ import {
 import { assert } from "../utils/mod.ts";
 import type { SockConn } from "../socket/socket.ts";
 
-export enum MqttConnError {
-  invalidPacket = "Invalid Packet",
-  packetTooLarge = "Packet too large",
-  UnexpectedEof = "Unexpected EOF",
-}
+export const MqttConnError = {
+  invalidPacket: "Invalid Packet",
+  packetTooLarge: "Packet too large",
+  UnexpectedEof: "Unexpected EOF",
+} as const;
 
 export interface IMqttConn extends AsyncIterable<AnyPacket> {
   readonly conn: SockConn;

--- a/mqttPacket/AuthenticationResult.ts
+++ b/mqttPacket/AuthenticationResult.ts
@@ -1,0 +1,16 @@
+/**
+ *  Possible MQTT authentication results
+ */
+
+export const AuthenticationResult = {
+  ok: 0,
+  unacceptableProtocol: 1,
+  rejectedUsername: 2,
+  serverUnavailable: 3,
+  badUsernameOrPassword: 4,
+  notAuthorized: 5,
+} as const;
+
+export const AuthenticationResultByNumber = Object.fromEntries(
+  Object.entries(AuthenticationResult).map(([k, v]) => [v, k]),
+);

--- a/mqttPacket/BitMask.ts
+++ b/mqttPacket/BitMask.ts
@@ -1,0 +1,10 @@
+export const BitMask = {
+  bit0: 2 ** 0,
+  bit1: 2 ** 1,
+  bit2: 2 ** 2,
+  bit3: 2 ** 3,
+  bit4: 2 ** 4,
+  bit5: 2 ** 5,
+  bit6: 2 ** 6,
+  bit7: 2 ** 7,
+} as const;

--- a/mqttPacket/PacketType.ts
+++ b/mqttPacket/PacketType.ts
@@ -1,0 +1,21 @@
+export const PacketType = {
+  reserved: 0,
+  connect: 1,
+  connack: 2,
+  publish: 3,
+  puback: 4,
+  pubrec: 5,
+  pubrel: 6,
+  pubcomp: 7,
+  subscribe: 8,
+  suback: 9,
+  unsubscribe: 10,
+  unsuback: 11,
+  pingreq: 12,
+  pingres: 13,
+  disconnect: 14,
+} as const;
+
+export const PacketNameByType = Object.fromEntries(
+  Object.entries(PacketType).map(([k, v]) => [v, k]),
+);

--- a/mqttPacket/connack.test.ts
+++ b/mqttPacket/connack.test.ts
@@ -1,4 +1,4 @@
-import { PacketType } from "./types.ts";
+import { PacketType } from "./PacketType.ts";
 import { assertEquals, assertThrows } from "../dev_utils/mod.ts";
 import { decode, encode } from "./mod.ts";
 

--- a/mqttPacket/connack.ts
+++ b/mqttPacket/connack.ts
@@ -1,22 +1,13 @@
-import { BitMask, PacketType } from "./types.ts";
+import type { TAuthenticationResult, TPacketType } from "./types.ts";
+import { PacketType } from "./PacketType.ts";
+import { BitMask } from "./BitMask.ts";
 import { booleanFlag, Decoder, DecoderError } from "./decoder.ts";
-
-/**
- *  Possible MQTT authentication results
- */
-export enum AuthenticationResult {
-  ok = 0,
-  unacceptableProtocol = 1,
-  rejectedUsername = 2,
-  serverUnavailable = 3,
-  badUsernameOrPassword = 4,
-  notAuthorized = 5,
-}
+import { AuthenticationResultByNumber } from "./AuthenticationResult.ts";
 
 export type ConnackPacket = {
-  type: PacketType.connack;
+  type: TPacketType;
   sessionPresent: boolean;
-  returnCode: AuthenticationResult;
+  returnCode: TAuthenticationResult;
 };
 
 export default {
@@ -32,9 +23,9 @@ export default {
     const decoder = new Decoder(buffer);
 
     const sessionPresent = booleanFlag(decoder.getByte(), BitMask.bit0);
-    const returnCode = decoder.getByte();
+    const returnCode = decoder.getByte() as TAuthenticationResult;
     decoder.done();
-    if (!AuthenticationResult[returnCode]) {
+    if (!AuthenticationResultByNumber[returnCode]) {
       throw new DecoderError("Invalid return code");
     }
     return {

--- a/mqttPacket/connect.test.ts
+++ b/mqttPacket/connect.test.ts
@@ -1,4 +1,4 @@
-import { PacketType } from "./types.ts";
+import { PacketType } from "./PacketType.ts";
 import { assertEquals, assertThrows } from "../dev_utils/mod.ts";
 import { type ConnectPacket, decode, encode } from "./mod.ts";
 

--- a/mqttPacket/connect.ts
+++ b/mqttPacket/connect.ts
@@ -1,11 +1,6 @@
-import {
-  BitMask,
-  type ClientId,
-  PacketType,
-  type Payload,
-  type QoS,
-  type Topic,
-} from "./types.ts";
+import type { ClientId, Payload, QoS, Topic, TPacketType } from "./types.ts";
+import { PacketType } from "./PacketType.ts";
+import { BitMask } from "./BitMask.ts";
 import { Encoder } from "./encoder.ts";
 import {
   booleanFlag,
@@ -15,7 +10,7 @@ import {
 } from "./decoder.ts";
 
 export type ConnectPacket = {
-  type: PacketType.connect;
+  type: TPacketType;
   protocolName?: string;
   protocolLevel?: number;
   clientId?: ClientId;

--- a/mqttPacket/decoder.ts
+++ b/mqttPacket/decoder.ts
@@ -1,9 +1,9 @@
-import type { BitMask, Topic, TopicFilter } from "./types.ts";
+import type { TBitMask, Topic, TopicFilter } from "./types.ts";
 import { invalidTopic, invalidTopicFilter } from "./validators.ts";
 
 const utf8Decoder = new TextDecoder("utf-8");
 
-export function booleanFlag(byte: number, mask: BitMask): boolean {
+export function booleanFlag(byte: number, mask: TBitMask): boolean {
   return !!(byte & mask);
 }
 

--- a/mqttPacket/disconnect.test.ts
+++ b/mqttPacket/disconnect.test.ts
@@ -1,4 +1,4 @@
-import { PacketType } from "./types.ts";
+import { PacketType } from "./PacketType.ts";
 import { assertEquals, assertThrows } from "../dev_utils/mod.ts";
 import { decode, encode } from "./mod.ts";
 

--- a/mqttPacket/disconnect.ts
+++ b/mqttPacket/disconnect.ts
@@ -1,8 +1,9 @@
-import { PacketType } from "./types.ts";
+import { PacketType } from "./PacketType.ts";
 import { isEmptyBuf } from "./decoder.ts";
+import type { TPacketType } from "./types.ts";
 
 export type DisconnectPacket = {
-  type: PacketType.disconnect;
+  type: TPacketType;
 };
 
 export default {

--- a/mqttPacket/pingreq.test.ts
+++ b/mqttPacket/pingreq.test.ts
@@ -1,4 +1,4 @@
-import { PacketType } from "./types.ts";
+import { PacketType } from "./PacketType.ts";
 import { assertEquals, assertThrows } from "../dev_utils/mod.ts";
 import { decode, encode } from "./mod.ts";
 

--- a/mqttPacket/pingreq.ts
+++ b/mqttPacket/pingreq.ts
@@ -1,8 +1,9 @@
-import { PacketType } from "./types.ts";
+import { PacketType } from "./PacketType.ts";
 import { hasEmptyFlags, isEmptyBuf } from "./decoder.ts";
+import type { TPacketType } from "./types.ts";
 
 export type PingreqPacket = {
-  type: PacketType.pingreq;
+  type: TPacketType;
 };
 
 export default {

--- a/mqttPacket/pingres.test.ts
+++ b/mqttPacket/pingres.test.ts
@@ -1,4 +1,4 @@
-import { PacketType } from "./types.ts";
+import { PacketType } from "./PacketType.ts";
 import { assertEquals, assertThrows } from "../dev_utils/mod.ts";
 import { decode, encode } from "./mod.ts";
 

--- a/mqttPacket/pingres.ts
+++ b/mqttPacket/pingres.ts
@@ -1,8 +1,9 @@
-import { PacketType } from "./types.ts";
+import { PacketType } from "./PacketType.ts";
 import { isEmptyBuf } from "./decoder.ts";
+import type { TPacketType } from "./types.ts";
 
 export type PingresPacket = {
-  type: PacketType.pingres;
+  type: TPacketType;
 };
 
 export default {

--- a/mqttPacket/puback.test.ts
+++ b/mqttPacket/puback.test.ts
@@ -1,4 +1,4 @@
-import { PacketType } from "./types.ts";
+import { PacketType } from "./PacketType.ts";
 import { assertEquals, assertThrows } from "../dev_utils/mod.ts";
 import { decode, encode } from "./mod.ts";
 

--- a/mqttPacket/puback.ts
+++ b/mqttPacket/puback.ts
@@ -1,9 +1,10 @@
-import { type PacketId, PacketType } from "./types.ts";
+import type { PacketId, TPacketType } from "./types.ts";
+import { PacketType } from "./PacketType.ts";
 import { Decoder } from "./decoder.ts";
 import { Encoder } from "./encoder.ts";
 
 export type PubackPacket = {
-  type: PacketType.puback;
+  type: TPacketType;
   id: PacketId;
 };
 

--- a/mqttPacket/pubcomp.test.ts
+++ b/mqttPacket/pubcomp.test.ts
@@ -1,4 +1,4 @@
-import { PacketType } from "./types.ts";
+import { PacketType } from "./PacketType.ts";
 import { assertEquals, assertThrows } from "../dev_utils/mod.ts";
 import { decode, encode } from "./mod.ts";
 

--- a/mqttPacket/pubcomp.ts
+++ b/mqttPacket/pubcomp.ts
@@ -1,9 +1,10 @@
-import { type PacketId, PacketType } from "./types.ts";
+import type { PacketId, TPacketType } from "./types.ts";
+import { PacketType } from "./PacketType.ts";
 import { Decoder } from "./decoder.ts";
 import { Encoder } from "./encoder.ts";
 
 export type PubcompPacket = {
-  type: PacketType.pubcomp;
+  type: TPacketType;
   id: PacketId;
 };
 

--- a/mqttPacket/publish.test.ts
+++ b/mqttPacket/publish.test.ts
@@ -1,4 +1,4 @@
-import { PacketType } from "./types.ts";
+import { PacketType } from "./PacketType.ts";
 import { assertEquals, assertThrows } from "../dev_utils/mod.ts";
 import { decode, encode } from "./mod.ts";
 

--- a/mqttPacket/publish.ts
+++ b/mqttPacket/publish.ts
@@ -1,15 +1,11 @@
-import {
-  BitMask,
-  PacketType,
-  type Payload,
-  type QoS,
-  type Topic,
-} from "./types.ts";
+import type { Payload, QoS, Topic, TPacketType } from "./types.ts";
+import { PacketType } from "./PacketType.ts";
+import { BitMask } from "./BitMask.ts";
 import { Encoder, EncoderError } from "./encoder.ts";
 import { booleanFlag, Decoder, DecoderError } from "./decoder.ts";
 
 export type PublishPacket = {
-  type: PacketType.publish;
+  type: TPacketType;
   topic: Topic;
   payload: Payload;
   dup?: boolean;

--- a/mqttPacket/pubrec.test.ts
+++ b/mqttPacket/pubrec.test.ts
@@ -1,4 +1,4 @@
-import { PacketType } from "./types.ts";
+import { PacketType } from "./PacketType.ts";
 import { assertEquals, assertThrows } from "../dev_utils/mod.ts";
 import { decode, encode } from "./mod.ts";
 

--- a/mqttPacket/pubrec.ts
+++ b/mqttPacket/pubrec.ts
@@ -1,9 +1,10 @@
-import { type PacketId, PacketType } from "./types.ts";
+import type { PacketId, TPacketType } from "./types.ts";
+import { PacketType } from "./PacketType.ts";
 import { Decoder } from "./decoder.ts";
 import { Encoder } from "./encoder.ts";
 
 export type PubrecPacket = {
-  type: PacketType.pubrec;
+  type: TPacketType;
   id: PacketId;
 };
 

--- a/mqttPacket/pubrel.test.ts
+++ b/mqttPacket/pubrel.test.ts
@@ -1,4 +1,4 @@
-import { PacketType } from "./types.ts";
+import { PacketType } from "./PacketType.ts";
 import { assertEquals, assertThrows } from "../dev_utils/mod.ts";
 import { decode, encode } from "./mod.ts";
 

--- a/mqttPacket/pubrel.ts
+++ b/mqttPacket/pubrel.ts
@@ -1,9 +1,10 @@
-import { type PacketId, PacketType } from "./types.ts";
+import type { PacketId, TPacketType } from "./types.ts";
+import { PacketType } from "./PacketType.ts";
 import { Decoder } from "./decoder.ts";
 import { Encoder } from "./encoder.ts";
 
 export type PubrelPacket = {
-  type: PacketType.pubrel;
+  type: TPacketType;
   id: PacketId;
 };
 

--- a/mqttPacket/suback.test.ts
+++ b/mqttPacket/suback.test.ts
@@ -1,4 +1,4 @@
-import { PacketType } from "./types.ts";
+import { PacketType } from "./PacketType.ts";
 import { assertEquals } from "../dev_utils/mod.ts";
 import { decode, encode } from "./mod.ts";
 

--- a/mqttPacket/suback.ts
+++ b/mqttPacket/suback.ts
@@ -1,9 +1,10 @@
-import { type PacketId, PacketType, type ReturnCodes } from "./types.ts";
+import type { PacketId, ReturnCodes, TPacketType } from "./types.ts";
+import { PacketType } from "./PacketType.ts";
 import { Encoder } from "./encoder.ts";
 import { Decoder } from "./decoder.ts";
 
 export type SubackPacket = {
-  type: PacketType.suback;
+  type: TPacketType;
   id: PacketId;
   returnCodes: ReturnCodes;
 };

--- a/mqttPacket/subscribe.test.ts
+++ b/mqttPacket/subscribe.test.ts
@@ -1,4 +1,4 @@
-import { PacketType } from "./types.ts";
+import { PacketType } from "./PacketType.ts";
 import { assertEquals, assertThrows } from "../dev_utils/mod.ts";
 import { decode, encode } from "./mod.ts";
 

--- a/mqttPacket/subscribe.ts
+++ b/mqttPacket/subscribe.ts
@@ -1,15 +1,11 @@
-import {
-  BitMask,
-  type PacketId,
-  PacketType,
-  type QoS,
-  type TopicFilter,
-} from "./types.ts";
+import type { PacketId, QoS, TopicFilter, TPacketType } from "./types.ts";
+import { PacketType } from "./PacketType.ts";
+import { BitMask } from "./BitMask.ts";
 import { Encoder } from "./encoder.ts";
 import { booleanFlag, Decoder, DecoderError } from "./decoder.ts";
 
 export type SubscribePacket = {
-  type: PacketType.subscribe;
+  type: TPacketType;
   id: PacketId;
   subscriptions: Subscription[];
 };

--- a/mqttPacket/types.ts
+++ b/mqttPacket/types.ts
@@ -1,31 +1,11 @@
-export enum PacketType {
-  reserved = 0,
-  connect = 1,
-  connack = 2,
-  publish = 3,
-  puback = 4,
-  pubrec = 5,
-  pubrel = 6,
-  pubcomp = 7,
-  subscribe = 8,
-  suback = 9,
-  unsubscribe = 10,
-  unsuback = 11,
-  pingreq = 12,
-  pingres = 13,
-  disconnect = 14,
-}
+import type { BitMask } from "./BitMask.ts";
+import type { PacketType } from "./PacketType.ts";
+import type { AuthenticationResult } from "./AuthenticationResult.ts";
 
-export enum BitMask {
-  bit0 = 2 ** 0,
-  bit1 = 2 ** 1,
-  bit2 = 2 ** 2,
-  bit3 = 2 ** 3,
-  bit4 = 2 ** 4,
-  bit5 = 2 ** 5,
-  bit6 = 2 ** 6,
-  bit7 = 2 ** 7,
-}
+export type TBitMask = typeof BitMask[keyof typeof BitMask];
+export type TPacketType = typeof PacketType[keyof typeof PacketType];
+export type TAuthenticationResult =
+  typeof AuthenticationResult[keyof typeof AuthenticationResult];
 
 export type QoS = 0 | 1 | 2;
 

--- a/mqttPacket/unsuback.test.ts
+++ b/mqttPacket/unsuback.test.ts
@@ -1,4 +1,4 @@
-import { PacketType } from "./types.ts";
+import { PacketType } from "./PacketType.ts";
 import { assertEquals, assertThrows } from "../dev_utils/mod.ts";
 import { decode, encode } from "./mod.ts";
 

--- a/mqttPacket/unsuback.ts
+++ b/mqttPacket/unsuback.ts
@@ -1,9 +1,10 @@
-import { type PacketId, PacketType } from "./types.ts";
+import type { PacketId, TPacketType } from "./types.ts";
+import { PacketType } from "./PacketType.ts";
 import { Decoder } from "./decoder.ts";
 import { Encoder } from "./encoder.ts";
 
 export type UnsubackPacket = {
-  type: PacketType.unsuback;
+  type: TPacketType;
   id: PacketId;
 };
 

--- a/mqttPacket/unsubscribe.test.ts
+++ b/mqttPacket/unsubscribe.test.ts
@@ -1,4 +1,4 @@
-import { PacketType } from "./types.ts";
+import { PacketType } from "./PacketType.ts";
 import { assertEquals, assertThrows } from "../dev_utils/mod.ts";
 import { decode, encode } from "./mod.ts";
 

--- a/mqttPacket/unsubscribe.ts
+++ b/mqttPacket/unsubscribe.ts
@@ -1,15 +1,11 @@
-import {
-  BitMask,
-  type PacketId,
-  PacketType,
-  type Topic,
-  type TopicFilter,
-} from "./types.ts";
+import type { PacketId, Topic, TopicFilter, TPacketType } from "./types.ts";
+import { PacketType } from "./PacketType.ts";
+import { BitMask } from "./BitMask.ts";
 import { Encoder } from "./encoder.ts";
 import { booleanFlag, Decoder, DecoderError } from "./decoder.ts";
 
 export type UnsubscribePacket = {
-  type: PacketType.unsubscribe;
+  type: TPacketType;
   id: PacketId;
   topicFilters: TopicFilter[];
 };

--- a/server/context.ts
+++ b/server/context.ts
@@ -1,13 +1,14 @@
 import {
   type AnyPacket,
-  type AuthenticationResult,
   type IPersistence,
   type IStore,
   logger,
   MqttConn,
+  PacketNameByType,
   PacketType,
   type PublishPacket,
   type SockConn,
+  type TAuthenticationResult,
   type Timer,
   type Topic,
 } from "./deps.ts";
@@ -32,7 +33,7 @@ export type Handlers = {
     clientId: ClientId,
     username: string,
     password: Uint8Array,
-  ): AuthenticationResult;
+  ): TAuthenticationResult;
   isAuthorizedToPublish?(ctx: Context, topic: Topic): boolean;
   isAuthorizedToSubscribe?(ctx: Context, topic: Topic): boolean;
 };
@@ -66,7 +67,7 @@ export class Context {
   }
 
   async send(packet: AnyPacket): Promise<void> {
-    logger.debug("Sending", PacketType[packet.type]);
+    logger.debug("Sending", PacketNameByType[packet.type]);
     logger.debug(JSON.stringify(packet, null, 2));
     await this.mqttConn.send(packet);
   }

--- a/server/deps.ts
+++ b/server/deps.ts
@@ -21,12 +21,17 @@ export type {
   SubackPacket,
   SubscribePacket,
   Subscription,
+  TAuthenticationResult,
   Topic,
   TopicFilter,
   UnsubackPacket,
   UnsubscribePacket,
 } from "../mqttPacket/mod.ts";
 
-export { AuthenticationResult, PacketType } from "../mqttPacket/mod.ts";
+export {
+  AuthenticationResult,
+  PacketNameByType,
+  PacketType,
+} from "../mqttPacket/mod.ts";
 export { Timer } from "../timer/timer.ts";
 export { logger } from "../utils/mod.ts";

--- a/server/handlers/handleConnect.ts
+++ b/server/handlers/handleConnect.ts
@@ -4,13 +4,14 @@ import {
   type ConnectPacket,
   logger,
   PacketType,
+  type TAuthenticationResult,
   Timer,
 } from "../deps.ts";
 
 function isAuthenticated(
   ctx: Context,
   packet: ConnectPacket,
-): AuthenticationResult {
+): TAuthenticationResult {
   if (ctx.handlers.isAuthenticated) {
     return ctx.handlers.isAuthenticated(
       ctx,
@@ -25,7 +26,7 @@ function isAuthenticated(
 function validateConnect(
   ctx: Context,
   packet: ConnectPacket,
-): AuthenticationResult {
+): TAuthenticationResult {
   if (packet.protocolLevel !== 4) {
     return AuthenticationResult.unacceptableProtocol;
   }

--- a/server/handlers/handlePacket.ts
+++ b/server/handlers/handlePacket.ts
@@ -1,5 +1,16 @@
 import type { Context } from "../context.ts";
-import { type AnyPacket, PacketType } from "../deps.ts";
+import {
+  type AnyPacket,
+  PacketNameByType,
+  PacketType,
+  type PubackPacket,
+  type PubcompPacket,
+  type PublishPacket,
+  type PubrecPacket,
+  type PubrelPacket,
+  type SubscribePacket,
+  type UnsubscribePacket,
+} from "../deps.ts";
 import { handleConnect } from "./handleConnect.ts";
 import { handlePingreq } from "./handlePingreq.ts";
 import { handlePublish } from "./handlePublish.ts";
@@ -16,14 +27,14 @@ export async function handlePacket(
   ctx: Context,
   packet: AnyPacket,
 ): Promise<void> {
-  logger.debug("handling", PacketType[packet.type]);
+  logger.debug("handling", PacketNameByType[packet.type]);
   logger.debug(JSON.stringify(packet, null, 2));
   if (!ctx.connected) {
     if (packet.type === PacketType.connect) {
       handleConnect(ctx, packet);
     } else {
       throw new Error(
-        `Received ${PacketType[packet.type]} packet before connect`,
+        `Received ${PacketNameByType[packet.type]} packet before connect`,
       );
     }
   } else {
@@ -32,32 +43,34 @@ export async function handlePacket(
         await handlePingreq(ctx);
         break;
       case PacketType.publish:
-        await handlePublish(ctx, packet);
+        await handlePublish(ctx, packet as PublishPacket);
         break;
       case PacketType.puback:
-        handlePuback(ctx, packet);
+        handlePuback(ctx, packet as PubackPacket);
         break;
       case PacketType.pubrel:
-        await handlePubrel(ctx, packet);
+        await handlePubrel(ctx, packet as PubrelPacket);
         break;
       case PacketType.pubrec:
-        await handlePubrec(ctx, packet);
+        await handlePubrec(ctx, packet as PubrecPacket);
         break;
       case PacketType.pubcomp:
-        handlePubcomp(ctx, packet);
+        handlePubcomp(ctx, packet as PubcompPacket);
         break;
       case PacketType.subscribe:
-        await handleSubscribe(ctx, packet);
+        await handleSubscribe(ctx, packet as SubscribePacket);
         break;
       case PacketType.unsubscribe:
-        await handleUnsubscribe(ctx, packet);
+        await handleUnsubscribe(ctx, packet as UnsubscribePacket);
         break;
       case PacketType.disconnect:
         handleDisconnect(ctx);
         break;
       default:
         throw new Error(
-          `Received unexpected ${PacketType[packet.type]} packet after connect`,
+          `Received unexpected ${
+            PacketNameByType[packet.type]
+          } packet after connect`,
         );
     }
     ctx.timer?.reset();

--- a/server/test/test-handlers.ts
+++ b/server/test/test-handlers.ts
@@ -1,5 +1,6 @@
 import { AuthenticationResult, type Context, type Topic } from "../mod.ts";
 import { logger } from "../../utils/mod.ts";
+import type { TAuthenticationResult } from "../deps.ts";
 
 const utf8Decoder = new TextDecoder();
 const userTable = new Map();
@@ -12,7 +13,7 @@ function isAuthenticated(
   clientId: string,
   username: string,
   password: Uint8Array,
-): AuthenticationResult {
+): TAuthenticationResult {
   const pwd = utf8Decoder.decode(password);
   logger.debug(
     `Verifying authentication of client '${clientId}' with username '${username}' and password '${pwd}'`,

--- a/utils/logger.ts
+++ b/utils/logger.ts
@@ -1,10 +1,12 @@
-export enum LogLevel {
-  error = 0,
-  warn = 1,
-  info = 2,
-  verbose = 3,
-  debug = 4,
-}
+export const LogLevel = {
+  error: 0,
+  warn: 1,
+  info: 2,
+  verbose: 3,
+  debug: 4,
+} as const;
+
+export type TLogLevel = typeof LogLevel[keyof typeof LogLevel];
 
 export class Logger {
   private defaultError = console.error;
@@ -22,7 +24,7 @@ export class Logger {
 
   constructor() {}
 
-  level(logLevel: LogLevel) {
+  level(logLevel: TLogLevel) {
     this.warn = logLevel > 0 ? this.defaultWarn : this.noop;
     this.info = logLevel > 1 ? this.defaultInfo : this.noop;
     this.verbose = logLevel > 2 ? this.defaultVerbose : this.noop;


### PR DESCRIPTION
This PR:
- replaces "enum" by "as const"
- adds explicit types like TPacketType, TAuthenticationResult
- adds helpers to convert back to readable names like ` AuthenticationResultByNumber`

Potential benefits: 
- helps achieving compatibility with `node --experimental-strip-types`
- Makes it easier to enable translation of error messages to other languages