### PR TITLE
client cert

### DIFF
--- a/client/client.ts
+++ b/client/client.ts
@@ -25,6 +25,8 @@ type ConnectOptions = Omit<
 export type ConnectParameters = {
   url?: URL;
   caCerts?: string[];
+  cert?: string;
+  key?: string;
   numberOfRetries?: number;
   options?: ConnectOptions;
 };
@@ -70,6 +72,8 @@ export class Client {
   protected keepAlive = DEFAULT_KEEPALIVE;
   protected autoReconnect = true;
   private caCerts?: string[];
+  private cert?: string;
+  private key?: string;
   private clientId: string;
   private ctx = new Context(new MemoryStore());
   private connectPacket?: ConnectPacket;
@@ -84,6 +88,8 @@ export class Client {
     _hostname: string,
     _port?: number,
     _caCerts?: string[],
+    _cert?: string,
+    _key?: string,
   ): Promise<SockConn> {
     // if you need to support alternative connection types just
     // overload this method in your subclass
@@ -106,6 +112,8 @@ export class Client {
           this.url.hostname,
           Number(this.url.port) ?? undefined,
           this.caCerts,
+          this.cert,
+          this.key,
         );
         // if we get this far we have a connection
         tryConnect =
@@ -137,6 +145,8 @@ export class Client {
     this.url = params?.url || this.url;
     this.numberOfRetries = params.numberOfRetries || this.numberOfRetries;
     this.caCerts = params?.caCerts;
+    this.cert = params?.cert;
+    this.key = params?.key;
     const options = Object.assign(
       {
         keepAlive: this.keepAlive,

--- a/deno/client.ts
+++ b/deno/client.ts
@@ -28,7 +28,7 @@ export class TcpClient extends Client {
     cert?: string,
     key?: string,
   ) {
-    logger.debug({ hostname, port, caCerts, cert, key });
+    logger.debug({ hostname, port, caCerts, cert });
     return await Deno.connectTls({ hostname, port, caCerts, cert, key });
   }
 

--- a/deno/client.ts
+++ b/deno/client.ts
@@ -25,9 +25,11 @@ export class TcpClient extends Client {
     hostname: string,
     port = 8883,
     caCerts?: string[],
+    cert?: string,
+    key?: string,
   ) {
-    logger.debug({ hostname, port, caCerts });
-    return await Deno.connectTls({ hostname, port, caCerts });
+    logger.debug({ hostname, port, caCerts, cert, key });
+    return await Deno.connectTls({ hostname, port, caCerts, cert, key });
   }
 
   protected override createConn(
@@ -35,11 +37,13 @@ export class TcpClient extends Client {
     hostname: string,
     port?: number,
     caCerts?: string[],
+    cert?: string,
+    key?: string,
   ): Promise<SockConn> {
     // if you need to support alternative connection types just
     // overload this method in your subclass
     if (protocol === "mqtts:") {
-      return this.connectMQTTS(hostname, port, caCerts);
+      return this.connectMQTTS(hostname, port, caCerts, cert, key);
     }
     if (protocol === "mqtt:") {
       return this.connectMQTT(hostname, port);


### PR DESCRIPTION
Adds cert and key to ConnectParams and passes down to Deno.connectTls().

Enables client to be used with MQTTS servers that use Client Certificate Authentication eg: [Event Grid](https://learn.microsoft.com/en-us/azure/event-grid/mqtt-client-certificate-authentication)