### PR TITLE
chore: update type imports

### DIFF
--- a/client/deps.ts
+++ b/client/deps.ts
@@ -34,3 +34,4 @@ export type { SockConn } from "../socket/socket.ts";
 export { Timer } from "../timer/timer.ts";
 export { AsyncQueue, Deferred, logger } from "../utils/mod.ts";
 export { MemoryStore } from "./store/memoryStore.ts";
+export { nextTick } from "../utils/mod.ts";

--- a/client/handlers/handleConnack.ts
+++ b/client/handlers/handleConnack.ts
@@ -1,6 +1,7 @@
 import type { Context } from "../context.ts";
 import { ConnectionState } from "../ConnectionState.ts";
-import { AuthenticationResultByNumber, type ConnackPacket } from "../deps.ts";
+import { AuthenticationResultByNumber } from "../deps.ts";
+import type { ConnackPacket } from "../deps.ts";
 
 /**
  * Handles the CONNACK packet received from the MQTT broker
@@ -15,7 +16,7 @@ export async function handleConnack(packet: ConnackPacket, ctx: Context) {
     ctx.unresolvedConnect?.resolve(packet.returnCode);
     // start transmitting packets that were queued before
     for await (const packet of ctx.store.pendingOutgoingPackets()) {
-      ctx.send(packet);
+      await ctx.send(packet);
     }
     return;
   }

--- a/client/handlers/handlePublish.ts
+++ b/client/handlers/handlePublish.ts
@@ -1,5 +1,6 @@
 import type { Context } from "../context.ts";
-import { PacketType, type PublishPacket } from "../deps.ts";
+import { PacketType } from "../deps.ts";
+import type { PublishPacket } from "../deps.ts";
 
 /**
  * Handles incoming MQTT publish packets based on their QoS level

--- a/client/handlers/handlePubrec.ts
+++ b/client/handlers/handlePubrec.ts
@@ -1,5 +1,6 @@
 import type { Context } from "../context.ts";
-import { PacketType, type PubrecPacket, type PubrelPacket } from "../deps.ts";
+import { PacketType } from "../deps.ts";
+import type { PubrecPacket, PubrelPacket } from "../deps.ts";
 
 /**
  * Handles PUBREC (Publish Received) packets for QoS 2 message flow

--- a/client/handlers/handlePubrel.ts
+++ b/client/handlers/handlePubrel.ts
@@ -1,5 +1,6 @@
 import type { Context } from "../context.ts";
-import { PacketType, type PubrelPacket } from "../deps.ts";
+import { PacketType } from "../deps.ts";
+import type { PubrelPacket } from "../deps.ts";
 
 /**
  * Handles a PUBREL packet in the MQTT QoS 2 flow

--- a/client/store/memoryStore.ts
+++ b/client/store/memoryStore.ts
@@ -2,7 +2,8 @@
  * @module memoryStore
  */
 
-import { assert, type PacketId } from "./deps.ts";
+import { assert } from "./deps.ts";
+import type { PacketId } from "./deps.ts";
 
 import {
   type IStore,

--- a/mqttConn/mqttConn.test.ts
+++ b/mqttConn/mqttConn.test.ts
@@ -1,8 +1,9 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import { makeDummySockConn } from "../dev_utils/mod.ts";
-import { type AnyPacket, encode, PacketType } from "../mqttPacket/mod.ts";
+import { encode, PacketType } from "../mqttPacket/mod.ts";
 import { MqttConn, MqttConnError } from "./mqttConn.ts";
+import type { AnyPacket } from "../mqttPacket/mod.ts";
 
 const connectPacket: AnyPacket = {
   type: PacketType.connect,

--- a/mqttPacket/connect.test.ts
+++ b/mqttPacket/connect.test.ts
@@ -2,7 +2,8 @@ import { PacketType } from "./PacketType.ts";
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { type ConnectPacket, decode, encode } from "./mod.ts";
+import { decode, encode } from "./mod.ts";
+import type { ConnectPacket } from "./mod.ts";
 
 test("encode Connect with ClientId", () => {
   assert.deepStrictEqual(

--- a/mqttPacket/mod.ts
+++ b/mqttPacket/mod.ts
@@ -20,25 +20,40 @@ import type {
 import { PacketNameByType, PacketType } from "./PacketType.ts";
 import { invalidTopic, invalidTopicFilter, invalidUTF8 } from "./validators.ts";
 import { decodeLength, encodeLength } from "./length.ts";
-import { connect, type ConnectPacket } from "./connect.ts";
-import { connack, type ConnackPacket } from "./connack.ts";
+import { connect } from "./connect.ts";
+import { connack } from "./connack.ts";
 import {
   AuthenticationResult,
   AuthenticationResultByNumber,
 } from "./AuthenticationResult.ts";
-import { publish, type PublishPacket } from "./publish.ts";
-import { puback, type PubackPacket } from "./puback.ts";
-import { pubrec, type PubrecPacket } from "./pubrec.ts";
-import { pubrel, type PubrelPacket } from "./pubrel.ts";
-import { pubcomp, type PubcompPacket } from "./pubcomp.ts";
-import { subscribe, type SubscribePacket } from "./subscribe.ts";
-import { suback, type SubackPacket } from "./suback.ts";
-import { unsubscribe, type UnsubscribePacket } from "./unsubscribe.ts";
-import { unsuback, type UnsubackPacket } from "./unsuback.ts";
-import { pingreq, type PingreqPacket } from "./pingreq.ts";
-import { pingres, type PingresPacket } from "./pingres.ts";
-import { disconnect, type DisconnectPacket } from "./disconnect.ts";
+import { publish } from "./publish.ts";
+import { puback } from "./puback.ts";
+import { pubrec } from "./pubrec.ts";
+import { pubrel } from "./pubrel.ts";
+import { pubcomp } from "./pubcomp.ts";
+import { subscribe } from "./subscribe.ts";
+import { suback } from "./suback.ts";
+import { unsubscribe } from "./unsubscribe.ts";
+import { unsuback } from "./unsuback.ts";
+import { pingreq } from "./pingreq.ts";
+import { pingres } from "./pingres.ts";
+import { disconnect } from "./disconnect.ts";
 import { DecoderError } from "./decoder.ts";
+
+import type { ConnectPacket } from "./connect.ts";
+import type { ConnackPacket } from "./connack.ts";
+import type { PublishPacket } from "./publish.ts";
+import type { PubackPacket } from "./puback.ts";
+import type { PubrecPacket } from "./pubrec.ts";
+import type { PubrelPacket } from "./pubrel.ts";
+import type { PubcompPacket } from "./pubcomp.ts";
+import type { SubscribePacket } from "./subscribe.ts";
+import type { SubackPacket } from "./suback.ts";
+import type { UnsubscribePacket } from "./unsubscribe.ts";
+import type { UnsubackPacket } from "./unsuback.ts";
+import type { PingreqPacket } from "./pingreq.ts";
+import type { PingresPacket } from "./pingres.ts";
+import type { DisconnectPacket } from "./disconnect.ts";
 
 /**
  * this can be any possible MQTT packet

--- a/persistence/memory/memoryPersistence.test.ts
+++ b/persistence/memory/memoryPersistence.test.ts
@@ -5,7 +5,8 @@ import {
 
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { PacketType, type PublishPacket } from "../deps.ts";
+import { PacketType } from "../deps.ts";
+import type { PublishPacket } from "../deps.ts";
 
 const payloadAny = new TextEncoder().encode("any");
 const qos = 1;

--- a/server/context.ts
+++ b/server/context.ts
@@ -1,16 +1,13 @@
-import {
-  type AnyPacket,
-  type IPersistence,
-  type IStore,
-  logger,
-  MqttConn,
-  PacketNameByType,
-  PacketType,
-  type PublishPacket,
-  type SockConn,
-  type TAuthenticationResult,
-  type Timer,
-  type Topic,
+import { logger, MqttConn, PacketNameByType, PacketType } from "./deps.ts";
+import type {
+  AnyPacket,
+  IPersistence,
+  IStore,
+  PublishPacket,
+  SockConn,
+  TAuthenticationResult,
+  Timer,
+  Topic,
 } from "./deps.ts";
 
 export type ClientId = string;

--- a/server/handlers/handleConnect.ts
+++ b/server/handlers/handleConnect.ts
@@ -1,12 +1,7 @@
 import type { Context } from "../context.ts";
-import {
-  AuthenticationResult,
-  type ConnectPacket,
-  logger,
-  PacketType,
-  type TAuthenticationResult,
-  Timer,
-} from "../deps.ts";
+import { AuthenticationResult, logger, PacketType, Timer } from "../deps.ts";
+
+import type { ConnectPacket, TAuthenticationResult } from "../deps.ts";
 
 /**
  * Checks if the client is authenticated based on the provided credentials

--- a/server/handlers/handlePacket.ts
+++ b/server/handlers/handlePacket.ts
@@ -1,15 +1,14 @@
 import type { Context } from "../context.ts";
-import {
-  type AnyPacket,
-  PacketNameByType,
-  PacketType,
-  type PubackPacket,
-  type PubcompPacket,
-  type PublishPacket,
-  type PubrecPacket,
-  type PubrelPacket,
-  type SubscribePacket,
-  type UnsubscribePacket,
+import { PacketNameByType, PacketType } from "../deps.ts";
+import type {
+  AnyPacket,
+  PubackPacket,
+  PubcompPacket,
+  PublishPacket,
+  PubrecPacket,
+  PubrelPacket,
+  SubscribePacket,
+  UnsubscribePacket,
 } from "../deps.ts";
 import { handleConnect } from "./handleConnect.ts";
 import { handlePingreq } from "./handlePingreq.ts";

--- a/server/handlers/handlePublish.ts
+++ b/server/handlers/handlePublish.ts
@@ -1,5 +1,7 @@
-import { type Context, SysPrefix } from "../context.ts";
-import { PacketType, type PublishPacket, type Topic } from "../deps.ts";
+import { SysPrefix } from "../context.ts";
+import { PacketType } from "../deps.ts";
+import type { Context } from "../context.ts";
+import type { PublishPacket, Topic } from "../deps.ts";
 
 /**
  * Checks if a client is authorized to publish to a given topic

--- a/server/handlers/handlePubrec.ts
+++ b/server/handlers/handlePubrec.ts
@@ -1,5 +1,6 @@
+import { PacketType } from "../deps.ts";
+import type { PubrecPacket } from "../deps.ts";
 import type { Context } from "../context.ts";
-import { PacketType, type PubrecPacket } from "../deps.ts";
 
 /**
  * Handles PUBREC (QoS 2 Publish Received) packets

--- a/server/handlers/handlePubrel.ts
+++ b/server/handlers/handlePubrel.ts
@@ -1,5 +1,6 @@
+import { PacketType } from "../deps.ts";
 import type { Context } from "../context.ts";
-import { PacketType, type PubrelPacket } from "../deps.ts";
+import type { PubrelPacket } from "../deps.ts";
 
 /**
  * Handles PUBREL (QoS 2 publish release) packets

--- a/server/handlers/handleSubscribe.ts
+++ b/server/handlers/handleSubscribe.ts
@@ -1,10 +1,6 @@
 import type { Context } from "../context.ts";
-import {
-  PacketType,
-  type SubscribePacket,
-  type Subscription,
-  type Topic,
-} from "../deps.ts";
+import { PacketType } from "../deps.ts";
+import type { SubscribePacket, Subscription, Topic } from "../deps.ts";
 
 /**
  * @constant {number} SubscriptionFailure

--- a/server/handlers/handleUnsubscribe.ts
+++ b/server/handlers/handleUnsubscribe.ts
@@ -1,5 +1,6 @@
+import { PacketType } from "../deps.ts";
+import type { UnsubscribePacket } from "../deps.ts";
 import type { Context } from "../context.ts";
-import { PacketType, type UnsubscribePacket } from "../deps.ts";
 
 /**
  * Handles MQTT unsubscribe packets by removing subscriptions and sending acknowledgement

--- a/server/server.ts
+++ b/server/server.ts
@@ -1,13 +1,7 @@
-import { Context, type Handlers } from "./context.ts";
-import {
-  AuthenticationResult,
-  type IPersistence,
-  logger,
-  MemoryPersistence,
-  type SockConn,
-  type Topic,
-} from "./deps.ts";
-
+import { AuthenticationResult, logger, MemoryPersistence } from "./deps.ts";
+import { Context } from "./context.ts";
+import type { Handlers } from "./context.ts";
+import type { IPersistence, SockConn, Topic } from "./deps.ts";
 import { handlePacket } from "./handlers/handlePacket.ts";
 
 const defaultIsAuthenticated = (
@@ -63,7 +57,7 @@ export class MqttServer {
     }
     try {
       for await (const packet of ctx.mqttConn) {
-        handlePacket(ctx, packet);
+        await handlePacket(ctx, packet);
       }
     } catch (err) {
       logger.debug(`Error while serving:${err}`);

--- a/server/test/test-handlers.ts
+++ b/server/test/test-handlers.ts
@@ -1,6 +1,7 @@
-import { AuthenticationResult, type Context, type Topic } from "../mod.ts";
+import { AuthenticationResult } from "../mod.ts";
 import { logger } from "../../utils/mod.ts";
 import type { TAuthenticationResult } from "../deps.ts";
+import type { Context, Topic } from "../mod.ts";
 
 const utf8Decoder = new TextDecoder();
 const userTable = new Map();

--- a/socket/socket.ts
+++ b/socket/socket.ts
@@ -62,8 +62,10 @@ export class Conn {
       this.closed = true;
       try {
         this.closer();
-      } // swallow any errors on close
-      catch (_err) {}
+      } 
+      catch (_err) { 
+        // swallow any errors on close 
+        }
     }
   }
 }

--- a/socket/socket.ts
+++ b/socket/socket.ts
@@ -60,7 +60,10 @@ export class Conn {
   close() {
     if (!this.closed) {
       this.closed = true;
-      this.closer();
+      try {
+        this.closer();
+      } // swallow any errors on close
+      catch (_err) {}
     }
   }
 }

--- a/socket/socket.ts
+++ b/socket/socket.ts
@@ -62,10 +62,9 @@ export class Conn {
       this.closed = true;
       try {
         this.closer();
-      } 
-      catch (_err) { 
-        // swallow any errors on close 
-        }
+      } catch (_err) {
+        // swallow any errors on close
+      }
     }
   }
 }


### PR DESCRIPTION
This PR turns:
`import { A, type B } from "mod.ts"`
into:
`import { A } from "mod.ts"`
`import type { B } from "mod.ts"`

