### PR TITLE
fix: typescript 5.9 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - chore: update dependencies
   - @types/node ^22.13.1 → ^24.1.0
+- fix: Typescript 5.9 compatibility issue
 
 ## [v1.9.4] 30-05-2025
 

--- a/deno.lock
+++ b/deno.lock
@@ -1,33 +1,23 @@
 {
-  "version": "4",
+  "version": "5",
   "specifiers": {
-    "npm:@types/node@*": "22.5.4",
-    "npm:@types/node@^22.13.1": "22.13.1"
+    "npm:@types/node@*": "22.5.4"
   },
   "npm": {
-    "@types/node@22.13.1": {
-      "integrity": "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew==",
-      "dependencies": [
-        "undici-types@6.20.0"
-      ]
-    },
     "@types/node@22.5.4": {
       "integrity": "sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==",
       "dependencies": [
-        "undici-types@6.19.8"
+        "undici-types"
       ]
     },
     "undici-types@6.19.8": {
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
-    },
-    "undici-types@6.20.0": {
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="
     }
   },
   "workspace": {
     "packageJson": {
       "dependencies": [
-        "npm:@types/node@^22.13.1"
+        "npm:@types/node@^24.1.0"
       ]
     }
   }

--- a/node/wrapNodeSocket.ts
+++ b/node/wrapNodeSocket.ts
@@ -26,8 +26,8 @@ export function wrapNodeSocket(socket: Socket): SockConn {
     {
       type: "bytes",
       start(controller) {
-        socket.on("data", (data) => {
-          controller.enqueue(new Uint8Array(data));
+        socket.on("data", (data: Uint8Array<ArrayBuffer>) => {
+          controller.enqueue(data);
           const desiredSize = controller.desiredSize ?? 0;
           if (desiredSize <= 0) {
             // The internal queue is full, so propagate

--- a/node/wrapNodeSocket.ts
+++ b/node/wrapNodeSocket.ts
@@ -24,7 +24,7 @@ export function wrapNodeSocket(socket: Socket): SockConn {
     {
       type: "bytes",
       start(controller) {
-        socket.on("data", (data: ArrayBufferView) => {
+        socket.on("data", (data) => {
           controller.enqueue(data);
           const desiredSize = controller.desiredSize ?? 0;
           if (desiredSize <= 0) {

--- a/node/wrapNodeSocket.ts
+++ b/node/wrapNodeSocket.ts
@@ -2,7 +2,6 @@
  * Utility functions for wrapping Node.js sockets into standard web streams.
  */
 import type { Socket } from "node:net";
-import type { Buffer } from "node:buffer";
 import { Writable } from "node:stream";
 import type { NetAddr, SockConn } from "../socket/socket.ts";
 

--- a/node/wrapNodeSocket.ts
+++ b/node/wrapNodeSocket.ts
@@ -2,8 +2,11 @@
  * Utility functions for wrapping Node.js sockets into standard web streams.
  */
 import type { Socket } from "node:net";
+import type { Buffer } from "node:buffer";
 import { Writable } from "node:stream";
 import type { NetAddr, SockConn } from "../socket/socket.ts";
+
+
 /**
  * Closes a Node.js socket if it is not already closed
  * @param sock - The Node.js socket to close
@@ -25,7 +28,7 @@ export function wrapNodeSocket(socket: Socket): SockConn {
       type: "bytes",
       start(controller) {
         socket.on("data", (data) => {
-          controller.enqueue(data);
+          controller.enqueue(new Uint8Array(data));
           const desiredSize = controller.desiredSize ?? 0;
           if (desiredSize <= 0) {
             // The internal queue is full, so propagate

--- a/node/wrapNodeSocket.ts
+++ b/node/wrapNodeSocket.ts
@@ -6,7 +6,6 @@ import type { Buffer } from "node:buffer";
 import { Writable } from "node:stream";
 import type { NetAddr, SockConn } from "../socket/socket.ts";
 
-
 /**
  * Closes a Node.js socket if it is not already closed
  * @param sock - The Node.js socket to close


### PR DESCRIPTION
This fixes the Typescript 5.9 compatibility issue that caused:
`error TS2345: Argument of type 'Buffer<ArrayBufferLike>' is not assignable to parameter of type 'ArrayBufferView<ArrayBuffer>'.`

See: https://devblogs.microsoft.com/typescript/announcing-typescript-5-9/