### PR TITLE
fix(subscription): fixes breaking subscription when using wildcards due to mismatched encoder method

### DIFF
--- a/mqttPacket/subscribe.ts
+++ b/mqttPacket/subscribe.ts
@@ -75,7 +75,7 @@ export const subscribe: {
       );
     }
     for (const sub of packet.subscriptions) {
-      encoder.setTopic(sub.topicFilter);
+      encoder.setTopicFilter(sub.topicFilter);
       if (packet.protocolLevel === 5) {
         const {
           qos,


### PR DESCRIPTION
Fixes #44 