### PR TITLE
chore: Eclipse Paho compatibility testing

### DIFF
--- a/tools/mqtt-compat/README.md
+++ b/tools/mqtt-compat/README.md
@@ -1,17 +1,18 @@
 # MQTT compatibility tests
 
-Measures Opifex's **actual** MQTT 5.0 and 3.1.1 protocol compatibility by running
-the vendor-neutral [Eclipse Paho interoperability suite][paho] against a broker
-booted from this repo, and reports an honest pass percentage. Wired into CI by
+Measures Opifex's **actual** MQTT 5.0 and 3.1.1 protocol compatibility by
+running the vendor-neutral [Eclipse Paho interoperability suite][paho] against a
+broker booted from this repo, and reports an honest pass percentage. Wired into
+CI by
 [`.github/workflows/mqtt-compat.yml`](../../.github/workflows/mqtt-compat.yml),
 which posts the result as a sticky PR comment and a job summary.
 
 ## Files
 
-| File            | Purpose                                                                                                           |
-| --------------- | ----------------------------------------------------------------------------------------------------------------- |
+| File            | Purpose                                                                                                            |
+| --------------- | ------------------------------------------------------------------------------------------------------------------ |
 | `broker.js`     | Boots Opifex on a plain-TCP port (`MQTT_PORT`, default 1883) with the v5 capabilities the suite exercises enabled. |
-| `run_compat.py` | Runs each Paho test in an isolated subprocess against the broker, emits `report.md` + `result.json`. Pure stdlib. |
+| `run_compat.py` | Runs each Paho test in an isolated subprocess against the broker, emits `report.md` + `result.json`. Pure stdlib.  |
 
 ## Running locally
 
@@ -69,8 +70,8 @@ reason string`. Pick the dict by what the
 failure _means_:
 
 - A genuine Opifex gap that should drag the score down → **`EXPECTED_GAPS`**. It
-  still runs and counts as a failure; when Opifex later implements it the harness
-  flags the 🎉 xpass so you remove the entry.
+  still runs and counts as a failure; when Opifex later implements it the
+  harness flags the 🎉 xpass so you remove the entry.
 - A test the harness can't fairly evaluate against _any_ broker →
   **`HARNESS_LIMITED`**. It is skipped before the gap logic and excluded from
   the denominator. A method must live in **exactly one** list (`HARNESS_LIMITED`

--- a/tools/mqtt-compat/README.md
+++ b/tools/mqtt-compat/README.md
@@ -1,0 +1,119 @@
+# MQTT compatibility tests
+
+Measures Opifex's **actual** MQTT 5.0 and 3.1.1 protocol compatibility by running
+the vendor-neutral [Eclipse Paho interoperability suite][paho] against a broker
+booted from this repo, and reports an honest pass percentage. Wired into CI by
+[`.github/workflows/mqtt-compat.yml`](../../.github/workflows/mqtt-compat.yml),
+which posts the result as a sticky PR comment and a job summary.
+
+## Files
+
+| File            | Purpose                                                                                                           |
+| --------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `broker.js`     | Boots Opifex on a plain-TCP port (`MQTT_PORT`, default 1883) with the v5 capabilities the suite exercises enabled. |
+| `run_compat.py` | Runs each Paho test in an isolated subprocess against the broker, emits `report.md` + `result.json`. Pure stdlib. |
+
+## Running locally
+
+```bash
+# 1. Fetch the Paho suite, pinned to the same commit CI uses so local results
+#    match. The pin (PAHO_REF) lives in .github/workflows/mqtt-compat.yml.
+git clone https://github.com/eclipse-paho/paho.mqtt.testing /tmp/paho
+git -C /tmp/paho checkout "$(grep -oP 'PAHO_REF:\s*\K\S+' \
+  ../../.github/workflows/mqtt-compat.yml)"
+
+# 2. Start the broker
+MQTT_PORT=1883 node tools/mqtt-compat/broker.ts &
+
+# 3. Run the suites
+python3 tools/mqtt-compat/run_compat.py \
+  --paho /tmp/paho/interoperability \
+  --host localhost --port 1883 \
+  --out report.md --json result.json
+```
+
+`--protocols v5,v3` selects the suites; `--timeout` bounds each test (default
+45s).
+
+## How the score is computed
+
+Each Paho `Test` method runs in its **own subprocess** with a hard timeout. This
+matters because the Paho clients do blocking waits with no internal timeout: a
+case where the broker never sends an expected packet would otherwise hang the
+whole run, and a hung test would corrupt the class-level shared clients later
+tests reuse. A timed-out test is recorded as a bounded failure.
+
+The percentage is the raw pass rate (`passed / evaluated`). Two categories are
+handled specially:
+
+- **Expected gaps** (`EXPECTED_GAPS` in `run_compat.py`) — features Opifex
+  intentionally does not implement yet (e.g. shared subscriptions, which the
+  broker advertises as `sharedSubscriptionAvailable=false`). These still count
+  as failures; they are only annotated with the reason so the table is readable.
+  Because v5 is a work in progress, the harness also detects the reverse: when
+  an `EXPECTED_GAPS` test starts **passing** (the feature got implemented), the
+  report highlights it with a 🎉 banner and the workflow emits a CI warning,
+  prompting you to remove the now-stale entry from `EXPECTED_GAPS`.
+- **Harness-limited** (`HARNESS_LIMITED`) — tests that cannot be evaluated under
+  per-test isolation against _any_ broker (currently only `test_flow_control2`,
+  which depends on the persistent client the suite sets up only in
+  single-process mode). These are **excluded** from the denominator. The
+  capability they probe is still measured elsewhere (`test_flow_control1` for
+  receive-maximum).
+
+### Adding or moving a test category
+
+Both lists in `run_compat.py` are keyed
+`protocol -> exact Paho method name ->
+reason string`. Pick the dict by what the
+failure _means_:
+
+- A genuine Opifex gap that should drag the score down → **`EXPECTED_GAPS`**. It
+  still runs and counts as a failure; when Opifex later implements it the harness
+  flags the 🎉 xpass so you remove the entry.
+- A test the harness can't fairly evaluate against _any_ broker →
+  **`HARNESS_LIMITED`**. It is skipped before the gap logic and excluded from
+  the denominator. A method must live in **exactly one** list (`HARNESS_LIMITED`
+  is checked first, so a duplicate `EXPECTED_GAPS` entry would be dead code).
+
+## Coverage scope — read the percentage correctly
+
+The percentage is **"% of the Paho functional suite that passes"**, not "%
+MQTT-5.0-compliant". The Paho suite is a third-party **happy-path functional**
+test: it exercises the user-facing v5 features well (session expiry, will + will
+delay, message expiry, RH/RAP/NL, request/response, payload format, assigned
+client id, server keep alive, inbound topic aliases, max-packet-size rejection,
+PUBLISH user properties), but it touches only 5 reason codes and deliberately
+omits large parts of the spec:
+
+- **Error / negative paths** — most of Opifex's reason codes
+  (`lib/constants.js`): `0x87` not-authorized acks, `0x8E` session takeover,
+  `0x82` protocol errors, `0x8C` bad auth method, `0x9E`, the CONNACK reject
+  codes, broker-initiated DISCONNECT with ReasonString, the oversized-frame read
+  latch, wildcard ResponseTopic rejection. These are covered by
+  **`test/mqtt5.js`**, which is the authoritative place Opifex's v5 error
+  semantics are pinned.
+- **Whole spec chapters** — AUTH / enhanced auth (§4.12), Server Reference
+  (`0x9C`/`0x9D`), CONNACK capability flags, ReasonString round-trips, and
+  UserProperty on non-PUBLISH packets. Some of these Opifex does not implement;
+  the test gap left by _both_ suites is tracked in
+  [#1096](https://github.com/moscajs/Opifex/issues/1096).
+
+So treat this workflow as the **cross-implementation functional gauge** and
+`test/mqtt5.js` as the **gap-filler** — they are complementary, not redundant.
+
+Some Paho failures are intentional Opifex design decisions rather than bugs (see
+`EXPECTED_GAPS`), and at least one is a genuine spec bug found by this suite:
+[#1095](https://github.com/moscajs/Opifex/issues/1095) (zero-length ClientId +
+CleanSession=0 must be rejected on v3.1.1).
+
+## Harness validation
+
+The harness was validated against the Paho project's own fully-compliant
+reference broker (`startbroker.py`): it scores **100%** of evaluated v5 tests
+(with `test_flow_control2` excluded as above). Every test Opifex fails, the
+reference broker passes under the identical harness — so a failure here reflects
+a real difference between Opifex and a spec-compliant broker, not a harness
+artifact.
+
+[paho]: https://github.com/eclipse-paho/paho.mqtt.testing

--- a/tools/mqtt-compat/broker.ts
+++ b/tools/mqtt-compat/broker.ts
@@ -1,0 +1,45 @@
+// Standalone aedes broker used by the MQTT compatibility workflow.
+//
+// It boots the broker from *this branch* on a plain-TCP port so the Eclipse Paho
+// interoperability suite (tools/mqtt-compat/run_compat.py) can drive it as an
+// external broker. v5 capabilities the suite exercises are enabled here so the
+// reported score reflects real broker ability, not a broker started with features
+// switched off (e.g. inbound topic aliases are a no-op when topicAliasMaximum: 0).
+//
+// Usage: MQTT_PORT=1883 node tools/mqtt-compat/broker.js
+import { TcpServer } from "../../node/tcpServer.ts";
+import type { Context, Topic } from "../../server/mod.ts";
+import { logger, LogLevel } from "../../utils/mod.ts";
+
+logger.level(LogLevel.info);
+
+const port = Number(process.env.MQTT_PORT) || 1883;
+
+// The Paho `test_subscribe_failure` (v3.1.1 and v5) subscribes to a topic that is
+// "not allowed to be subscribed to" and asserts the broker answers with SUBACK
+// reason code 0x80.
+
+const NO_SUBSCRIBE_TOPIC = "test/nosubscribe";
+
+function isAuthorizedToSubscribe(ctx: Context, topic: Topic): boolean {
+  logger.debug(
+    `Checking authorization of client '${ctx.store?.clientId}' to subscribe to topic '${topic}'`,
+  );
+  return topic !== NO_SUBSCRIBE_TOPIC;
+}
+
+const tcpServer = new TcpServer({ port }, {
+  handlers: {
+    isAuthorizedToSubscribe,
+  },
+});
+tcpServer.start();
+logger.info(`Server started on port ${tcpServer.port}`);
+
+function shutdown() {
+  tcpServer.stop();
+  process.exit(0);
+}
+
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", shutdown);

--- a/tools/mqtt-compat/mqtt-compat.yml
+++ b/tools/mqtt-compat/mqtt-compat.yml
@@ -1,0 +1,125 @@
+name: MQTT Compatibility
+
+# Measures aedes's actual MQTT 5.0 + 3.1.1 compatibility by running the vendor-
+# neutral Eclipse Paho interoperability suite against a broker booted from this
+# branch, then posts the pass-rate as a sticky PR comment and a job summary.
+
+on:
+  #pull_request:
+  #  types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write # required to post/update the sticky comment
+
+# Supersede in-flight runs for the same PR (or ref) so rapid pushes can't race
+# the sticky comment into duplicates or overwrite a newer result with a stale one.
+concurrency:
+  group: mqtt-compat-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Pinned Paho commit: keeps results reproducible and the module-global contract
+  # run_compat.py relies on stable. Bump deliberately.
+  PAHO_REF: 9d7bb80bb8b9d9cfc0b52f8cb4c1916401281103
+  MQTT_PORT: 1883
+
+jobs:
+  compat:
+    name: Paho interoperability
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: package.json
+
+      - name: Install dependencies
+        run: npm install --ignore-scripts
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Fetch Paho interoperability suite (pinned)
+        run: |
+          git clone --filter=blob:none --no-checkout https://github.com/eclipse-paho/paho.mqtt.testing paho
+          git -C paho checkout "$PAHO_REF"
+
+      - name: Start aedes broker
+        run: |
+          node tools/mqtt-compat/broker.js &
+          echo "BROKER_PID=$!" >> "$GITHUB_ENV"
+          python - "$MQTT_PORT" <<'PY'
+          import socket, sys, time
+          port = int(sys.argv[1])
+          for _ in range(100):
+              try:
+                  socket.create_connection(("localhost", port), 0.3).close()
+                  print(f"broker is up on {port}"); sys.exit(0)
+              except OSError:
+                  time.sleep(0.2)
+          print(f"broker did not come up on {port}"); sys.exit(1)
+          PY
+
+      - name: Run compatibility suites
+        run: |
+          python tools/mqtt-compat/run_compat.py \
+            --paho paho/interoperability \
+            --host localhost --port "${MQTT_PORT}" \
+            --timeout 45 \
+            --out report.md --json result.json
+
+      - name: Stop aedes broker
+        if: always()
+        run: kill "${BROKER_PID}" 2>/dev/null || true
+
+      - name: Warn on unexpected passes
+        if: always()
+        run: |
+          [ -f result.json ] || exit 0
+          python - <<'PY'
+          import json, os
+          data = json.load(open("result.json"))
+          xpass = [f"{t['name']} ({p['label']})"
+                   for p in data["protocols"] for t in p["results"]
+                   if t.get("unexpected_pass")]
+          if xpass:
+              names = ", ".join(xpass)
+              print(f"::warning title=MQTT compat: update EXPECTED_GAPS::"
+                    f"{len(xpass)} expected-gap test(s) now pass: {names}. "
+                    f"Remove them from EXPECTED_GAPS in "
+                    f"tools/mqtt-compat/run_compat.py.")
+          PY
+
+      - name: Job summary
+        if: always()
+        run: cat report.md >> "$GITHUB_STEP_SUMMARY"
+
+      # Only same-repo PRs can post a comment: fork PRs get a read-only GITHUB_TOKEN
+      # (the property that makes this workflow safe to run untrusted code), so the
+      # API call would 403 and fail the job for every external contributor. Forks
+      # still get the job summary above. continue-on-error guards transient API
+      # failures so a posting hiccup never reds the compat result.
+      - name: Sticky PR comment
+        if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        continue-on-error: true
+        uses: ./.github/actions/sticky-pr-comment
+        with:
+          file: report.md
+          tag: "<!-- MQTT_COMPAT_COMMENT -->"
+
+      - name: Upload result artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: mqtt-compat-result
+          path: |
+            report.md
+            result.json
+          retention-days: 14

--- a/tools/mqtt-compat/mqtt-compat.yml
+++ b/tools/mqtt-compat/mqtt-compat.yml
@@ -1,6 +1,6 @@
 name: MQTT Compatibility
 
-# Measures aedes's actual MQTT 5.0 + 3.1.1 compatibility by running the vendor-
+# Measures Opifex's actual MQTT 5.0 + 3.1.1 compatibility by running the vendor-
 # neutral Eclipse Paho interoperability suite against a broker booted from this
 # branch, then posts the pass-rate as a sticky PR comment and a job summary.
 
@@ -51,9 +51,9 @@ jobs:
           git clone --filter=blob:none --no-checkout https://github.com/eclipse-paho/paho.mqtt.testing paho
           git -C paho checkout "$PAHO_REF"
 
-      - name: Start aedes broker
+      - name: Start Opifex broker
         run: |
-          node tools/mqtt-compat/broker.js &
+          node tools/mqtt-compat/broker.ts &
           echo "BROKER_PID=$!" >> "$GITHUB_ENV"
           python - "$MQTT_PORT" <<'PY'
           import socket, sys, time
@@ -75,7 +75,7 @@ jobs:
             --timeout 45 \
             --out report.md --json result.json
 
-      - name: Stop aedes broker
+      - name: Stop Opifex broker
         if: always()
         run: kill "${BROKER_PID}" 2>/dev/null || true
 

--- a/tools/mqtt-compat/run_compat.py
+++ b/tools/mqtt-compat/run_compat.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""Run the Eclipse Paho interoperability suites against a running broker and
+report an honest MQTT compatibility percentage.
+
+The Paho suites (``client_test5.py`` for MQTT 5.0, ``client_test.py`` for MQTT
+3.1.1) are ``unittest.TestCase`` classes whose ``__main__`` blocks parse argv
+with getopt and call ``unittest.main()`` (which ``sys.exit()``s and prints no
+machine-readable summary). We import each file as a module instead, set the
+module-level globals the tests read (``host``/``port``/``topics``/... — normally
+assigned only inside that ``__main__`` block) and run each ``Test`` method
+**in its own subprocess with a hard timeout**.
+
+Per-test subprocess isolation matters: the Paho clients do blocking waits with
+no internal timeout, so a case where the broker never sends an expected packet
+would otherwise hang the whole run, and a hung test would corrupt the
+class-level shared clients (``aclient``/``bclient``) used by later tests. A
+timed-out test is recorded as a (bounded) failure, keeping the run finite.
+
+The reported percentage is the raw pass rate (passed / tests that ran). Cases
+Opifex intentionally does not satisfy yet are NOT removed from the denominator —
+they are annotated as "expected" in the per-test table so the number stays
+honest while reviewers still see why a case fails.
+
+Pure standard library; no pip dependencies (the Paho suite ships its own MQTT
+packet de/serialiser under ``interoperability/mqtt``).
+"""
+
+import argparse
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import unittest
+
+
+# Cases Opifex intentionally does not (yet) satisfy. Keyed by protocol -> test
+# name -> reason. These still count as failures in the raw %; they render with an
+# "expected" marker and the reason in the per-test table.
+EXPECTED_GAPS = {
+    "v5": {
+        "test_shared_subscriptions":
+            "Opifex advertises sharedSubscriptionAvailable=false "
+            "(deferred for now)",
+        "test_flow_control1":
+            "receiveMaximum is advertised but not yet enforced outbound "
+        # NOTE: test_flow_control2 is NOT listed here — it lives in HARNESS_LIMITED
+        # below (skipped before the gap logic runs), so a duplicate entry here would
+        # be unreachable. The receiveMaximum gap it probes is tracked via
+        # test_flow_control1 above.
+        "test_server_topic_alias":
+            "broker-assigned topic aliases are not implemented;"
+            "spec-optional/MAY",
+        "test_subscribe_identifiers":
+            "a delivery matching multiple overlapping subscriptions echoes only one "
+            "Subscription Identifier ( [MQTT-3.3.4-4])",
+    },
+    "v3": {},
+}
+
+PROTOCOL_LABEL = {"v5": "MQTT 5.0", "v3": "MQTT 3.1.1"}
+TEST_FILES = {"v5": "client_test5.py", "v3": "client_test.py"}
+
+# Tests the per-test runner cannot evaluate, independent of the broker under
+# test. These are *excluded* from the denominator (rendered as skipped) because
+# they also fail against the Eclipse Paho reference broker under this harness's
+# per-test isolation — so a failure here says nothing about the broker. The
+# underlying capability is still measured elsewhere where possible.
+HARNESS_LIMITED = {
+    "v5": {
+        "test_flow_control2":
+            "not evaluable under per-test isolation (reuses the persistent "
+            "client id / background receiver the Paho suite only sets up in its "
+            "single-process mode); the Paho reference broker also hangs it here. "
+            "The receiveMaximum behaviour it probes is still measured by "
+            "test_flow_control1.",
+    },
+    "v3": {},
+}
+
+
+def load_module(paho_dir, protocol):
+    """Import a Paho test file as a uniquely-named module."""
+    path = os.path.join(paho_dir, TEST_FILES[protocol])
+    name = f"paho_{protocol}"
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def set_globals(module, protocol, host, port):
+    """Reproduce the module globals the suite's ``__main__`` block assigns.
+
+    Values mirror each file's ``__main__`` block verbatim (including the v5
+    ``client_test5/`` topic prefix) so results match a direct
+    ``python3 client_testN.py --hostname H --port P`` run.
+
+    This duplication is exactly what ``PAHO_REF`` (pinned in
+    ``.github/workflows/mqtt-compat.yml``) protects: a Paho bump that renames or
+    adds a module global the tests read would surface here as a ``NameError`` ->
+    "error" status. When bumping the pin, re-check each suite's ``__main__`` block
+    against this function.
+    """
+    module.host = host
+    module.port = port
+    module.nosubscribe_topics = ("test/nosubscribe",)
+    if protocol == "v5":
+        prefix = "client_test5/"
+        names = ["TopicA", "TopicA/B", "Topic/C", "TopicA/C", "/TopicA"]
+        wild = ["TopicA/+", "+/C", "#", "/#", "/+", "+/+", "TopicA/#"]
+        module.topic_prefix = prefix
+        module.topics = [prefix + t for t in names]
+        module.wildtopics = [prefix + t for t in wild]
+    else:
+        module.topics = ("TopicA", "TopicA/B", "Topic/C", "TopicA/C", "/TopicA")
+        module.wildtopics = ("TopicA/+", "+/C", "#", "/#", "/+", "+/+", "TopicA/#")
+
+
+# Prefix the worker's JSON result so the parent can find it unambiguously. The
+# Paho clients (and Python's interpreter shutdown) can emit stray stdout, so
+# "the last line is the JSON" is not a safe contract — we scan for this sentinel
+# instead, and a worker that prints after us still can't displace the result.
+RESULT_SENTINEL = "__MQTT_COMPAT_RESULT__:"
+
+
+def _last_line(text):
+    """The final non-empty line of a traceback — the assertion/exception message."""
+    lines = [ln.strip() for ln in (text or "").strip().splitlines() if ln.strip()]
+    return lines[-1] if lines else ""
+
+
+# --------------------------------------------------------------------------- #
+# Worker: run a single test method in this process and print a JSON result.
+# Status is derived from the result counters rather than per-test callbacks, so a
+# setUpClass error (recorded against an _ErrorHolder, not the test method) is
+# still attributed to this test instead of crashing the worker.
+# --------------------------------------------------------------------------- #
+def run_worker(args):
+    module = load_module(args.paho, args.protocol)
+    set_globals(module, args.protocol, args.host, args.port)
+    suite = unittest.TestSuite([module.Test(args.test)])
+    result = unittest.TestResult()
+    suite.run(result)
+    if result.skipped:
+        status, message = "skip", result.skipped[0][1]
+    elif result.failures:
+        status, message = "fail", _last_line(result.failures[0][1])
+    elif result.errors:
+        status, message = "error", _last_line(result.errors[0][1])
+    else:
+        status, message = "pass", ""
+    sys.stdout.write("\n" + RESULT_SENTINEL
+                     + json.dumps({"status": status, "message": message}) + "\n")
+    sys.stdout.flush()
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# Parent: discover test names, run each in an isolated subprocess, aggregate.
+# --------------------------------------------------------------------------- #
+def run_one_subprocess(args, protocol, test_name):
+    cmd = [
+        sys.executable, os.path.abspath(__file__), "--worker",
+        "--paho", args.paho, "--worker-protocol", protocol, "--test", test_name,
+        "--host", args.host, "--port", str(args.port),
+    ]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True,
+                              timeout=args.timeout)
+    except subprocess.TimeoutExpired:
+        return ("timeout", f"exceeded {args.timeout}s timeout")
+    # Find the sentinel-tagged result line (scan in reverse: last one wins if a
+    # rerun ever printed more than once). Robust to arbitrary stray stdout before
+    # or after it.
+    line = next((ln[len(RESULT_SENTINEL):]
+                 for ln in reversed(proc.stdout.splitlines())
+                 if ln.startswith(RESULT_SENTINEL)), "")
+    try:
+        payload = json.loads(line)
+        return (payload["status"], payload.get("message", ""))
+    except (ValueError, KeyError):
+        msg = (proc.stderr.strip().splitlines()[-1:] or ["worker produced no result"])[0]
+        return ("error", msg[:200])
+
+
+def run_protocol(args, protocol):
+    module = load_module(args.paho, protocol)
+    names = unittest.TestLoader().getTestCaseNames(module.Test)
+    print(f"\n=== {PROTOCOL_LABEL[protocol]}: {len(names)} tests ===", file=sys.stderr)
+
+    gaps = EXPECTED_GAPS.get(protocol, {})
+    limited = HARNESS_LIMITED.get(protocol, {})
+    results = []
+    passed = ran = 0
+    for name in names:
+        if name in limited:
+            print(f"  {name}: skipped (harness-limited)", file=sys.stderr)
+            results.append({"name": name, "status": "skip",
+                            "expected_gap": False, "note": limited[name]})
+            continue
+        status, message = run_one_subprocess(args, protocol, name)
+        print(f"  {name}: {status}", file=sys.stderr)
+        if status == "skip":
+            results.append({"name": name, "status": status,
+                            "expected_gap": False, "note": message})
+            continue
+        ran += 1
+        if status == "pass":
+            passed += 1
+        # A test listed in EXPECTED_GAPS that now PASSES is an "unexpected pass":
+        # the underlying feature was implemented (v5 is a work in progress), so the
+        # gap annotation is stale and EXPECTED_GAPS must be updated.
+        unexpected_pass = status == "pass" and name in gaps
+        is_gap = name in gaps and status != "pass"
+        if unexpected_pass:
+            note = ("was an expected gap but now PASSES — remove it from "
+                    "EXPECTED_GAPS in tools/mqtt-compat/run_compat.py")
+        elif status == "pass":
+            note = ""
+        elif is_gap:
+            note = gaps[name]
+        else:
+            note = message
+        results.append({
+            "name": name,
+            "status": status,
+            "expected_gap": is_gap,
+            "unexpected_pass": unexpected_pass,
+            "note": note,
+        })
+
+    percentage = round(100 * passed / ran) if ran else 0
+    return {
+        "protocol": protocol,
+        "label": PROTOCOL_LABEL[protocol],
+        "passed": passed,
+        "total": ran,
+        "skipped": len(names) - ran,
+        "percentage": percentage,
+        "results": results,
+    }
+
+
+STATUS_ICON = {"pass": "✅", "fail": "❌", "error": "💥", "timeout": "⏱️", "skip": "⏭️"}
+
+
+def render_markdown(reports):
+    lines = [
+        "## 📊 MQTT Compatibility Report",
+        "",
+        "Opifex tested against the "
+        "[Eclipse Paho interoperability suite]"
+        "(https://github.com/eclipse-paho/paho.mqtt.testing) "
+        "(the vendor-neutral broker conformance suite used by Mosquitto, EMQX, mochi-mqtt, …).",
+        "",
+        "| Protocol | Compatibility | Passed | Total |",
+        "|----------|---------------|--------|-------|",
+    ]
+    for r in reports:
+        lines.append(f"| {r['label']} | **{r['percentage']}%** | "
+                     f"{r['passed']} | {r['total']} |")
+    lines.append("")
+
+    # Surface unexpected passes (a known gap that now works) prominently: v5 is a
+    # work in progress, so this means a feature got implemented and the gap list is
+    # now stale.
+    xpass = [(r["label"], t["name"]) for r in reports for t in r["results"]
+             if t.get("unexpected_pass")]
+    if xpass:
+        listed = ", ".join(f"`{name}` ({label})" for label, name in xpass)
+        lines += [
+            f"> 🎉 **{len(xpass)} test(s) marked as an expected gap now PASS:** {listed}.",
+            ">",
+            "> A previously-unsupported feature now works. Please update "
+            "`EXPECTED_GAPS` in `tools/mqtt-compat/run_compat.py` so it is no longer "
+            "treated as a known failure.",
+            "",
+        ]
+
+    for r in reports:
+        gaps = sum(1 for t in r["results"] if t["expected_gap"])
+        summary = f"{r['label']} — {r['passed']}/{r['total']} passed"
+        if gaps:
+            summary += f" ({gaps} expected gap{'s' if gaps != 1 else ''})"
+        lines += [f"<details><summary>{summary}</summary>", "",
+                  "| Test | Result | Notes |", "|------|--------|-------|"]
+        for t in r["results"]:
+            cell = STATUS_ICON.get(t["status"], "❔")
+            if t.get("unexpected_pass"):
+                cell += " 🎉 update gaps"
+            elif t["expected_gap"]:
+                cell += " ⚠️ expected"
+            note = t["note"].replace("|", "\\|") if t["note"] else ""
+            lines.append(f"| `{t['name']}` | {cell} | {note} |")
+        lines += ["", "</details>", ""]
+
+    lines.append("<sub>⚠️ expected = a feature Opifex intentionally does not "
+                 "implement yet, counted as a failure in the raw percentage. "
+                 "🎉 update gaps = an expected gap that now passes — update "
+                 "`EXPECTED_GAPS`.</sub>")
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--paho", required=True,
+                        help="path to paho.mqtt.testing/interoperability")
+    parser.add_argument("--host", default="localhost")
+    parser.add_argument("--port", type=int, default=1883)
+    parser.add_argument("--out", default="report.md", help="Markdown report path")
+    parser.add_argument("--json", dest="json_out", default="result.json",
+                        help="machine-readable JSON path")
+    parser.add_argument("--protocols", default="v5,v3",
+                        help="comma-separated subset of: v5,v3")
+    parser.add_argument("--timeout", type=int, default=45,
+                        help="per-test timeout in seconds")
+    parser.add_argument("--worker", action="store_true", help=argparse.SUPPRESS)
+    # Internal worker flag; named distinctly from the public --protocols to avoid a
+    # one-character-off mix-up. dest=protocol keeps run_worker reading args.protocol.
+    parser.add_argument("--worker-protocol", dest="protocol", help=argparse.SUPPRESS)
+    parser.add_argument("--test", help=argparse.SUPPRESS)
+    args = parser.parse_args()
+
+    # The suite imports its own `mqtt` package relative to the interoperability dir.
+    sys.path.insert(0, os.path.abspath(args.paho))
+
+    if args.worker:
+        sys.exit(run_worker(args))
+
+    reports = [run_protocol(args, p.strip())
+               for p in args.protocols.split(",") if p.strip()]
+
+    markdown = render_markdown(reports)
+    with open(args.out, "w", encoding="utf-8") as fh:
+        fh.write(markdown + "\n")
+    with open(args.json_out, "w", encoding="utf-8") as fh:
+        json.dump({"protocols": reports}, fh, indent=2)
+
+    for r in reports:
+        print(f"{r['label']}: {r['percentage']}% ({r['passed']}/{r['total']})",
+              file=sys.stderr)
+
+    # CI-agnostic signal for "expected gap now passes" so the workflow can turn it
+    # into a warning annotation without re-parsing the report.
+    xpass = [(r["label"], t["name"]) for r in reports for t in r["results"]
+             if t.get("unexpected_pass")]
+    if xpass:
+        listed = ", ".join(f"{name} ({label})" for label, name in xpass)
+        print(f"UNEXPECTED_PASS: {listed}", file=sys.stderr)
+        print("These tests are in EXPECTED_GAPS but now pass; update "
+              "tools/mqtt-compat/run_compat.py.", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,6 +33,7 @@
   "include": ["bin/*.ts"],
   "exclude": [
     "dist",
+    "tools",
     "deno",
     "node_modules"
   ]


### PR DESCRIPTION
This PR adds a github action that enables MQTT 3.11 and 5 compatibility testing.
Borrowed from github.com/moscajs/aedes