### PR TITLE
fix: reduce disconnect logging

### DIFF
--- a/server/context.ts
+++ b/server/context.ts
@@ -247,7 +247,7 @@ export class Context {
         void this.handleWill();
       }
     } else {
-      logger.info(
+      logger.debug(
         `closing connection from ${this.mqttConn.remoteAddress} because of "${
           this.mqttConn.reason || "normal disconnect"
         }"`,


### PR DESCRIPTION
This PR ensures that only a lingle line is logged at level "info" when a client disconnects