### PR TITLE
chore: rename getSubscriptions to listSubscriptions

### DIFF
--- a/persistence/memory/memoryPersistence.ts
+++ b/persistence/memory/memoryPersistence.ts
@@ -96,7 +96,7 @@ export class MemoryPersistence implements IPersistence {
     this.pendingAckOutgoingTable.delete(clientId);
     this.packetIdCounters.delete(clientId);
     // make sure the subscriptions are removed from the trie
-    const subs = await Array.fromAsync(this.getSubscriptions(clientId));
+    const subs = await Array.fromAsync(this.listSubscriptions(clientId));
     for (const { topicFilter } of subs) {
       this.unsubscribe(clientId, topicFilter);
     }
@@ -131,7 +131,7 @@ export class MemoryPersistence implements IPersistence {
     return Promise.resolve();
   }
 
-  async *getSubscriptions(
+  async *listSubscriptions(
     clientId: ClientId,
   ): AsyncIterableIterator<{ topicFilter: TopicFilter; qos: QoS }> {
     const clientSubs = this.subscriptionTable.get(clientId);

--- a/persistence/persistence.testing.ts
+++ b/persistence/persistence.testing.ts
@@ -96,7 +96,7 @@ export function runPersistenceTestSuite(options: PersistenceFactoryOptions) {
       await persistence.subscribe("client1", "test/topic", 1);
 
       const subs = await Array.fromAsync(
-        persistence.getSubscriptions("client1"),
+        persistence.listSubscriptions("client1"),
       );
       const match = subs.find((s) => s.topicFilter === "test/topic");
 
@@ -113,7 +113,7 @@ export function runPersistenceTestSuite(options: PersistenceFactoryOptions) {
       await persistence.unsubscribe("client1", "test/topic");
 
       const subs = await Array.fromAsync(
-        persistence.getSubscriptions("client1"),
+        persistence.listSubscriptions("client1"),
       );
       const match = subs.find((s) => s.topicFilter === "test/topic");
       assert(match === undefined);
@@ -127,7 +127,7 @@ export function runPersistenceTestSuite(options: PersistenceFactoryOptions) {
       // Should not throw
       await persistence.unsubscribe("client1", "nonexistent/topic");
       const subs = await Array.fromAsync(
-        persistence.getSubscriptions("client1"),
+        persistence.listSubscriptions("client1"),
       );
       assert.strictEqual(subs.length, 0);
       cleanup();
@@ -365,7 +365,7 @@ export function runPersistenceTestSuite(options: PersistenceFactoryOptions) {
 
       assert.strictEqual(existingSession, true);
       const subs = await Array.fromAsync(
-        persistence.getSubscriptions("client1"),
+        persistence.listSubscriptions("client1"),
       );
       assert.strictEqual(subs.length, 1);
       assert.strictEqual(subs[0].topicFilter, "test/topic");
@@ -415,7 +415,7 @@ export function runPersistenceTestSuite(options: PersistenceFactoryOptions) {
 
       assert.strictEqual(existingSession, false);
       const subs = await Array.fromAsync(
-        persistence.getSubscriptions("client1"),
+        persistence.listSubscriptions("client1"),
       );
       assert.strictEqual(subs.length, 0);
       const inPkts = await Array.fromAsync(
@@ -441,7 +441,7 @@ export function runPersistenceTestSuite(options: PersistenceFactoryOptions) {
 
       await persistence.subscribe("client1", "", 0);
       const subs = await Array.fromAsync(
-        persistence.getSubscriptions("client1"),
+        persistence.listSubscriptions("client1"),
       );
       const match = subs.find((s) => s.topicFilter === "");
       assert(match !== undefined);
@@ -493,7 +493,7 @@ export function runPersistenceTestSuite(options: PersistenceFactoryOptions) {
       }
 
       const subs = await Array.fromAsync(
-        persistence.getSubscriptions("client1"),
+        persistence.listSubscriptions("client1"),
       );
       assert.strictEqual(subs.length, 100);
       cleanup();
@@ -509,7 +509,7 @@ export function runPersistenceTestSuite(options: PersistenceFactoryOptions) {
       }
 
       const subs = await Array.fromAsync(
-        persistence.getSubscriptions("client1"),
+        persistence.listSubscriptions("client1"),
       );
       assert.strictEqual(subs.length, 0);
       cleanup();
@@ -664,7 +664,7 @@ export function runPersistenceTestSuite(options: PersistenceFactoryOptions) {
       await Promise.all(operations);
 
       const subs = await Array.fromAsync(
-        persistence.getSubscriptions("client1"),
+        persistence.listSubscriptions("client1"),
       );
       assert(subs.length <= 20);
       cleanup();

--- a/persistence/persistence.ts
+++ b/persistence/persistence.ts
@@ -45,7 +45,7 @@ export interface IPersistence {
   // subscription management
   subscribe(clientId: ClientId, topic: TopicFilter, qos: QoS): Promise<void>;
   unsubscribe(clientId: ClientId, topic: TopicFilter): Promise<void>;
-  getSubscriptions(
+  listSubscriptions(
     clientId: ClientId,
   ): AsyncIterableIterator<{ topicFilter: TopicFilter; qos: QoS }>;
 

--- a/persistence/sqlite/sqlitePersistence.ts
+++ b/persistence/sqlite/sqlitePersistence.ts
@@ -151,7 +151,7 @@ export class SqlitePersistence implements IPersistence {
     this.clientHandlerList.delete(clientId);
 
     // Explicitly remove subscriptions from the in-memory trie first
-    for await (const { topicFilter } of this.getSubscriptions(clientId)) {
+    for await (const { topicFilter } of this.listSubscriptions(clientId)) {
       const stmt = this.db.prepare(
         "select qos from subscriptions where client_id = ? and topic = ?",
       );
@@ -207,7 +207,7 @@ export class SqlitePersistence implements IPersistence {
     return Promise.resolve();
   }
 
-  async *getSubscriptions(
+  async *listSubscriptions(
     clientId: ClientId,
   ): AsyncIterableIterator<{ topicFilter: TopicFilter; qos: QoS }> {
     const stmt = this.db.prepare(
@@ -479,7 +479,7 @@ export class SqlitePersistence implements IPersistence {
       return;
     }
 
-    for await (const { topicFilter } of this.getSubscriptions(clientId)) {
+    for await (const { topicFilter } of this.listSubscriptions(clientId)) {
       for (const retainedPacket of this.retainedMatches(topicFilter)) {
         await handler(retainedPacket);
       }

--- a/server/handlers/session.persistence.test.ts
+++ b/server/handlers/session.persistence.test.ts
@@ -86,7 +86,7 @@ test("subscriptions persist with clean=false", async () => {
   const client1 = mqttServer.persistence.clientHandlerList.get(clientId);
   assert(client1, "Expected client store for client-sub-persist");
   const client1Subs = await Array.fromAsync(
-    mqttServer.persistence.getSubscriptions(clientId),
+    mqttServer.persistence.listSubscriptions(clientId),
   );
   assert.strictEqual(
     client1Subs.length,
@@ -126,7 +126,7 @@ test("subscriptions persist with clean=false", async () => {
     "Expected client store present after reconnection",
   );
   const client2Subs = await Array.fromAsync(
-    mqttServer.persistence.getSubscriptions(clientId),
+    mqttServer.persistence.listSubscriptions(clientId),
   );
   assert.strictEqual(
     client1Subs.length,
@@ -165,7 +165,7 @@ test("subscriptions cleared with clean=true", async () => {
   const client1 = mqttServer.persistence.clientHandlerList.get(clientId);
   assert(client1, "Expected client store for client-sub-persist");
   const storedSubs = await Array.fromAsync(
-    mqttServer.persistence.getSubscriptions(clientId),
+    mqttServer.persistence.listSubscriptions(clientId),
   );
   assert.strictEqual(
     storedSubs.length,
@@ -192,7 +192,7 @@ test("subscriptions cleared with clean=true", async () => {
     "Expected client handler for client-clean after reconnection",
   );
   const cleanedSubs = await Array.fromAsync(
-    mqttServer.persistence.getSubscriptions(clientId),
+    mqttServer.persistence.listSubscriptions(clientId),
   );
   assert.strictEqual(
     cleanedSubs.length,


### PR DESCRIPTION
a leftover from the persistence refactor
all functions using generators are now called listXXY