### PR TITLE
chore: simplify mqttPacket exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,19 +5,20 @@
 ### Changed
 
 - feat: replace BYOD stream by Default Readable/Writable stream
-- feat: close connection on unauthorized publish (was ignore)
-- feat: add preconnect timeout
-- feat: set default max incoming message size to 2Kb (was 2Mb)
-- feat: add TLS client and server
-- feat: add WebSocket client and server
-- feat: refactor server persistence and add sqlite based persistence
-- feat: add Eclipse paho compatibility testing
+- feat(server): close connection on unauthorized publish (was ignore)
+- feat(server): add preconnect timeout
+- feat(server): set default max incoming message size to 2Kb (was 2Mb)
+- feat: limit max number of topic and topicFilter levels to 50
+- feat(server): add TLS client and server
+- feat(server): add WebSocket client and server
+- feat(server): refactor server persistence and add sqlite based persistence
+- feat(server): add Eclipse paho compatibility testing
 - chore: add many more tests
 - chore: remove .vscode files from repo
 - chore: move benchmarks to tools folder
-- fix: fix empty payload to clear retained message
+- chore: simplify mqttPacket encoder/decoder exports
+- fix(server): fix empty payload to clear retained message
 - fix: remove password from demo logging and debug logging
-- fix: limit max number of topic and topicFilter levels to 50
 
 ## [v1.11.3] 31-05-2026
 

--- a/mqttPacket/auth.ts
+++ b/mqttPacket/auth.ts
@@ -21,53 +21,43 @@ export type AuthPacketV5 = {
  */
 export type AuthPacket = AuthPacketV5;
 
-export const auth: {
-  encode(packet: AuthPacket, codecOpts: CodecOpts): Uint8Array;
-  decode(
-    buffer: Uint8Array,
-    flags: number,
-    codecOpts: CodecOpts,
-    packetType: TPacketType,
-  ): AuthPacket;
-} = {
-  encode(packet: AuthPacket, codecOpts: CodecOpts): Uint8Array {
-    // deno-coverage-ignore-start
-    if (packet.protocolLevel !== 5) {
-      throw new EncoderError("Invalid protocol level");
-    }
-    // deno-coverage-ignore-stop
-    const encoder = new Encoder(packet.type);
-    encoder
-      .setReasonCode(packet.reasonCode || 0)
-      .setProperties(
-        packet.properties || {},
-        packet.type,
-        codecOpts.maxOutgoingPacketSize,
-      );
-    return encoder.done(0);
-  },
+export function encode(packet: AuthPacket, codecOpts: CodecOpts): Uint8Array {
+  // deno-coverage-ignore-start
+  if (packet.protocolLevel !== 5) {
+    throw new EncoderError("Invalid protocol level");
+  }
+  // deno-coverage-ignore-stop
+  const encoder = new Encoder(packet.type);
+  encoder
+    .setReasonCode(packet.reasonCode || 0)
+    .setProperties(
+      packet.properties || {},
+      packet.type,
+      codecOpts.maxOutgoingPacketSize,
+    );
+  return encoder.done(0);
+}
 
-  decode(
-    buffer: Uint8Array,
-    flags: number,
-    codecOpts: CodecOpts,
-    packetType: TPacketType,
-  ): AuthPacket {
-    // Bits 3,2,1 and 0 of the Fixed Header of the AUTH packet are reserved and MUST all be set to 0.
-    // The Client or Server MUST treat any other value as malformed and close the Network Connection [MQTT-3.15.1-1].
-    hasEmptyFlags(flags);
-    if (codecOpts.protocolLevel !== 5) {
-      throw new DecoderError("Invalid protocol level");
-    }
-    const decoder = new Decoder(packetType, buffer);
-    const reasonCode = decoder.getReasonCode();
-    const properties = decoder.getProperties(PacketType.auth);
-    decoder.done();
-    return {
-      type: PacketType.auth,
-      protocolLevel: 5,
-      reasonCode,
-      properties,
-    };
-  },
-};
+export function decode(
+  buffer: Uint8Array,
+  flags: number,
+  codecOpts: CodecOpts,
+  packetType: TPacketType,
+): AuthPacket {
+  // Bits 3,2,1 and 0 of the Fixed Header of the AUTH packet are reserved and MUST all be set to 0.
+  // The Client or Server MUST treat any other value as malformed and close the Network Connection [MQTT-3.15.1-1].
+  hasEmptyFlags(flags);
+  if (codecOpts.protocolLevel !== 5) {
+    throw new DecoderError("Invalid protocol level");
+  }
+  const decoder = new Decoder(packetType, buffer);
+  const reasonCode = decoder.getReasonCode();
+  const properties = decoder.getProperties(PacketType.auth);
+  decoder.done();
+  return {
+    type: PacketType.auth,
+    protocolLevel: 5,
+    reasonCode,
+    properties,
+  };
+}

--- a/mqttPacket/connack.ts
+++ b/mqttPacket/connack.ts
@@ -38,71 +38,64 @@ export type ConnackPacketV5 = {
  */
 export type ConnackPacket = ConnackPacketV4 | ConnackPacketV5;
 
-export const connack: {
-  encode(packet: ConnackPacket, codecOpts: CodecOpts): Uint8Array;
-  decode(
-    buffer: Uint8Array,
-    flags: number,
-    codecOpts: CodecOpts,
-    packetType: TPacketType,
-  ): ConnackPacket;
-} = {
-  encode(packet: ConnackPacket, codecOpts: CodecOpts): Uint8Array {
-    if (packet.protocolLevel !== 5) {
-      return new Uint8Array([
-        packet.type << 4,
-        2,
-        packet.sessionPresent ? 1 : 0,
-        packet.returnCode || 0,
-      ]);
-    }
-    const encoder = new Encoder(packet.type);
-    encoder
-      .setByte(packet.sessionPresent ? 1 : 0)
-      .setReasonCode(packet.reasonCode || 0)
-      .setProperties(
-        packet.properties || {},
-        packet.type,
-        codecOpts.maxOutgoingPacketSize,
-      );
-    return encoder.done(0);
-  },
+export function encode(
+  packet: ConnackPacket,
+  codecOpts: CodecOpts,
+): Uint8Array {
+  if (packet.protocolLevel !== 5) {
+    return new Uint8Array([
+      packet.type << 4,
+      2,
+      packet.sessionPresent ? 1 : 0,
+      packet.returnCode || 0,
+    ]);
+  }
+  const encoder = new Encoder(packet.type);
+  encoder
+    .setByte(packet.sessionPresent ? 1 : 0)
+    .setReasonCode(packet.reasonCode || 0)
+    .setProperties(
+      packet.properties || {},
+      packet.type,
+      codecOpts.maxOutgoingPacketSize,
+    );
+  return encoder.done(0);
+}
 
-  decode(
-    buffer: Uint8Array,
-    flags: number,
-    codecOpts: CodecOpts,
-    packetType: TPacketType,
-  ): ConnackPacket {
-    const decoder = new Decoder(packetType, buffer);
-    hasEmptyFlags(flags);
-    const ackflags = decoder.getByte();
-    if (ackflags > 1) {
-      throw new DecoderError("Invalid Connect Acknowledge flags");
-    }
-    const sessionPresent = booleanFlag(ackflags, BitMask.bit0);
-    if (codecOpts.protocolLevel !== 5) {
-      const returnCode = decoder.getByte() as TAuthenticationResult;
-      decoder.done();
-      if (!AuthenticationResultByNumber[returnCode]) {
-        throw new DecoderError("Invalid return code");
-      }
-      return {
-        type: PacketType.connack,
-        protocolLevel: codecOpts.protocolLevel,
-        sessionPresent,
-        returnCode,
-      };
-    }
-    const reasonCode = decoder.getReasonCode();
-    const properties = decoder.getProperties(PacketType.connack);
+export function decode(
+  buffer: Uint8Array,
+  flags: number,
+  codecOpts: CodecOpts,
+  packetType: TPacketType,
+): ConnackPacket {
+  const decoder = new Decoder(packetType, buffer);
+  hasEmptyFlags(flags);
+  const ackflags = decoder.getByte();
+  if (ackflags > 1) {
+    throw new DecoderError("Invalid Connect Acknowledge flags");
+  }
+  const sessionPresent = booleanFlag(ackflags, BitMask.bit0);
+  if (codecOpts.protocolLevel !== 5) {
+    const returnCode = decoder.getByte() as TAuthenticationResult;
     decoder.done();
+    if (!AuthenticationResultByNumber[returnCode]) {
+      throw new DecoderError("Invalid return code");
+    }
     return {
       type: PacketType.connack,
-      protocolLevel: 5,
+      protocolLevel: codecOpts.protocolLevel,
       sessionPresent,
-      reasonCode,
-      properties,
+      returnCode,
     };
-  },
-};
+  }
+  const reasonCode = decoder.getReasonCode();
+  const properties = decoder.getProperties(PacketType.connack);
+  decoder.done();
+  return {
+    type: PacketType.connack,
+    protocolLevel: 5,
+    sessionPresent,
+    reasonCode,
+    properties,
+  };
+}

--- a/mqttPacket/connect.ts
+++ b/mqttPacket/connect.ts
@@ -76,223 +76,214 @@ function invalidProtocolName(version: number, name: string): boolean {
   return true;
 }
 
-export const connect: {
-  encode(packet: ConnectPacket, _codecOpts: CodecOpts): Uint8Array;
-  decode(
-    buffer: Uint8Array,
-    flags: number,
-    codecOpts: CodecOpts,
-    packetType: TPacketType,
-  ): ConnectPacket;
-} = {
-  encode(packet: ConnectPacket, codecOpts: CodecOpts): Uint8Array {
-    const flags = 0;
+export function encode(
+  packet: ConnectPacket,
+  codecOpts: CodecOpts,
+): Uint8Array {
+  const flags = 0;
 
-    // deno-coverage-ignore-start
-    if (typeof packet.protocolLevel !== "number") {
-      throw new EncoderError("Protocol level must be a number");
+  // deno-coverage-ignore-start
+  if (typeof packet.protocolLevel !== "number") {
+    throw new EncoderError("Protocol level must be a number");
+  }
+  const protocolLevel = packet.protocolLevel || 4;
+  if (protocolLevel < 3 || protocolLevel > 5) {
+    throw new EncoderError("Unsupported protocol level");
+  }
+  // deno-coverage-ignore-stop
+  const protocolName = protocolLevel > 3 ? "MQTT" : "MQIsdp";
+  const clientId = packet.clientId || "";
+  const usernameFlag = packet.username !== undefined;
+  if (protocolLevel === 3 && clientId === "") {
+    throw new EncoderError("Client id required for protocol level 3");
+  }
+  const passwordFlag = usernameFlag && packet.password !== undefined;
+  const willRetain = !!packet.will?.retain;
+  const willQoS = packet.will?.qos || 0;
+  const willFlag = packet.will !== undefined;
+  if (willFlag) {
+    if (packet.will?.topic === undefined) {
+      throw new EncoderError("Will topic must be defined");
     }
-    const protocolLevel = packet.protocolLevel || 4;
-    if (protocolLevel < 3 || protocolLevel > 5) {
-      throw new EncoderError("Unsupported protocol level");
+    if (packet.will?.payload === undefined) {
+      throw new EncoderError("Will payload must be defined");
     }
-    // deno-coverage-ignore-stop
-    const protocolName = protocolLevel > 3 ? "MQTT" : "MQIsdp";
-    const clientId = packet.clientId || "";
-    const usernameFlag = packet.username !== undefined;
-    if (protocolLevel === 3 && clientId === "") {
-      throw new EncoderError("Client id required for protocol level 3");
-    }
-    const passwordFlag = usernameFlag && packet.password !== undefined;
-    const willRetain = !!packet.will?.retain;
-    const willQoS = packet.will?.qos || 0;
-    const willFlag = packet.will !== undefined;
-    if (willFlag) {
-      if (packet.will?.topic === undefined) {
-        throw new EncoderError("Will topic must be defined");
-      }
-      if (packet.will?.payload === undefined) {
-        throw new EncoderError("Will payload must be defined");
-      }
-    }
-    const cleanSession = packet.clean !== false;
-    if (!cleanSession && (clientId === "")) {
-      throw new EncoderError("Client id required for clean session");
-    }
-    const connectFlags = (usernameFlag ? BitMask.bit7 : 0) +
-      (passwordFlag ? BitMask.bit6 : 0) +
-      (willRetain ? BitMask.bit5 : 0) +
-      (willQoS & 2 ? BitMask.bit4 : 0) +
-      (willQoS & 1 ? BitMask.bit3 : 0) +
-      (willFlag ? BitMask.bit2 : 0) +
-      (cleanSession ? BitMask.bit1 : 0);
-    const keepAlive = packet.keepAlive || 0;
-    const bridgeMode = !!packet.bridgeMode;
-    const rawProtocolLevel = bridgeMode ? protocolLevel + 128 : protocolLevel;
+  }
+  const cleanSession = packet.clean !== false;
+  if (!cleanSession && (clientId === "")) {
+    throw new EncoderError("Client id required for clean session");
+  }
+  const connectFlags = (usernameFlag ? BitMask.bit7 : 0) +
+    (passwordFlag ? BitMask.bit6 : 0) +
+    (willRetain ? BitMask.bit5 : 0) +
+    (willQoS & 2 ? BitMask.bit4 : 0) +
+    (willQoS & 1 ? BitMask.bit3 : 0) +
+    (willFlag ? BitMask.bit2 : 0) +
+    (cleanSession ? BitMask.bit1 : 0);
+  const keepAlive = packet.keepAlive || 0;
+  const bridgeMode = !!packet.bridgeMode;
+  const rawProtocolLevel = bridgeMode ? protocolLevel + 128 : protocolLevel;
 
-    const encoder = new Encoder(packet.type);
-    encoder
-      .setUtf8String(protocolName)
-      .setByte(rawProtocolLevel)
-      .setByte(connectFlags)
-      .setInt16(keepAlive);
+  const encoder = new Encoder(packet.type);
+  encoder
+    .setUtf8String(protocolName)
+    .setByte(rawProtocolLevel)
+    .setByte(connectFlags)
+    .setInt16(keepAlive);
+  if (packet.protocolLevel === 5) {
+    encoder.setProperties(
+      packet.properties || {},
+      PropertySetType.connect,
+      codecOpts.maxOutgoingPacketSize,
+    );
+  }
+  encoder.setUtf8String(clientId);
+
+  if (
+    packet.will !== undefined && packet.will.topic !== undefined &&
+    packet.will.payload !== undefined
+  ) {
     if (packet.protocolLevel === 5) {
       encoder.setProperties(
-        packet.properties || {},
-        PropertySetType.connect,
+        packet.will?.properties || {},
+        PropertySetType.will,
         codecOpts.maxOutgoingPacketSize,
       );
     }
-    encoder.setUtf8String(clientId);
+    encoder.setTopic(packet.will.topic).setByteArray(packet.will.payload);
+  }
 
-    if (
-      packet.will !== undefined && packet.will.topic !== undefined &&
-      packet.will.payload !== undefined
-    ) {
-      if (packet.protocolLevel === 5) {
-        encoder.setProperties(
-          packet.will?.properties || {},
-          PropertySetType.will,
-          codecOpts.maxOutgoingPacketSize,
-        );
-      }
-      encoder.setTopic(packet.will.topic).setByteArray(packet.will.payload);
-    }
+  if (packet.username !== undefined) {
+    encoder.setUtf8String(packet.username);
+  }
 
-    if (packet.username !== undefined) {
-      encoder.setUtf8String(packet.username);
-    }
+  if (passwordFlag && packet.password !== undefined) {
+    encoder.setByteArray(packet.password);
+  }
+  return encoder.done(flags);
+}
 
-    if (passwordFlag && packet.password !== undefined) {
-      encoder.setByteArray(packet.password);
-    }
-    return encoder.done(flags);
-  },
+export function decode(
+  buffer: Uint8Array,
+  flags: number,
+  _codecOpts: CodecOpts,
+  packetType: TPacketType,
+): ConnectPacket {
+  const decoder = new Decoder(packetType, buffer);
+  const protocolName = decoder.getUTF8String();
+  const rawProtocolLevel = decoder.getByte();
+  const bridgeMode = rawProtocolLevel > 128;
+  const protocolLevel = bridgeMode ? rawProtocolLevel - 128 : rawProtocolLevel;
 
-  decode(
-    buffer: Uint8Array,
-    flags: number,
-    _codecOpts: CodecOpts,
-    packetType: TPacketType,
-  ): ConnectPacket {
-    const decoder = new Decoder(packetType, buffer);
-    const protocolName = decoder.getUTF8String();
-    const rawProtocolLevel = decoder.getByte();
-    const bridgeMode = rawProtocolLevel > 128;
-    const protocolLevel = bridgeMode
-      ? rawProtocolLevel - 128
-      : rawProtocolLevel;
+  if (invalidProtocolName(protocolLevel, protocolName)) {
+    throw new DecoderError("Invalid protocol name or level");
+  }
 
-    if (invalidProtocolName(protocolLevel, protocolName)) {
-      throw new DecoderError("Invalid protocol name or level");
-    }
+  const connectFlags = decoder.getByte();
 
-    const connectFlags = decoder.getByte();
+  const usernameFlag = booleanFlag(connectFlags, BitMask.bit7);
+  const passwordFlag = booleanFlag(connectFlags, BitMask.bit6);
+  const willRetain = booleanFlag(connectFlags, BitMask.bit5);
+  const willQoS = (connectFlags & (BitMask.bit4 + BitMask.bit3)) >> 3;
+  const willFlag = booleanFlag(connectFlags, BitMask.bit2);
+  const cleanSession = booleanFlag(connectFlags, BitMask.bit1);
+  const reservedBit = booleanFlag(connectFlags, BitMask.bit0);
 
-    const usernameFlag = booleanFlag(connectFlags, BitMask.bit7);
-    const passwordFlag = booleanFlag(connectFlags, BitMask.bit6);
-    const willRetain = booleanFlag(connectFlags, BitMask.bit5);
-    const willQoS = (connectFlags & (BitMask.bit4 + BitMask.bit3)) >> 3;
-    const willFlag = booleanFlag(connectFlags, BitMask.bit2);
-    const cleanSession = booleanFlag(connectFlags, BitMask.bit1);
-    const reservedBit = booleanFlag(connectFlags, BitMask.bit0);
+  hasEmptyFlags(flags);
+  // The Server MUST validate that the reserved flag in the CONNECT Control Packet
+  // is set to zero and disconnect the Client if it is not zero [MQTT-3.1.2-3].
+  if (reservedBit) {
+    throw new DecoderError("Invalid reserved bit");
+  }
 
-    hasEmptyFlags(flags);
-    // The Server MUST validate that the reserved flag in the CONNECT Control Packet
-    // is set to zero and disconnect the Client if it is not zero [MQTT-3.1.2-3].
-    if (reservedBit) {
-      throw new DecoderError("Invalid reserved bit");
-    }
+  if (willQoS !== 0 && willQoS !== 1 && willQoS !== 2) {
+    throw new DecoderError("Invalid will qos");
+  }
 
-    if (willQoS !== 0 && willQoS !== 1 && willQoS !== 2) {
-      throw new DecoderError("Invalid will qos");
-    }
+  if (!usernameFlag && passwordFlag) {
+    throw new DecoderError("Password without username");
+  }
 
-    if (!usernameFlag && passwordFlag) {
-      throw new DecoderError("Password without username");
-    }
-
-    const keepAlive = decoder.getInt16();
-    const isV5 = protocolLevel === 5;
-    let properties;
+  const keepAlive = decoder.getInt16();
+  const isV5 = protocolLevel === 5;
+  let properties;
+  if (isV5) {
+    properties = decoder.getProperties(PropertySetType.connect);
+  }
+  const clientId = decoder.getUTF8String();
+  let willProperties;
+  let willTopic;
+  let willPayload;
+  if (willFlag) {
     if (isV5) {
-      properties = decoder.getProperties(PropertySetType.connect);
+      willProperties = decoder.getProperties(PropertySetType.will);
     }
-    const clientId = decoder.getUTF8String();
-    let willProperties;
-    let willTopic;
-    let willPayload;
-    if (willFlag) {
-      if (isV5) {
-        willProperties = decoder.getProperties(PropertySetType.will);
-      }
-      willTopic = decoder.getTopic();
-      willPayload = decoder.getByteArray();
-    }
+    willTopic = decoder.getTopic();
+    willPayload = decoder.getByteArray();
+  }
 
-    let username;
-    let password;
-    if (usernameFlag) {
-      username = decoder.getUTF8String();
-    }
+  let username;
+  let password;
+  if (usernameFlag) {
+    username = decoder.getUTF8String();
+  }
 
-    if (passwordFlag) {
-      password = decoder.getByteArray();
-    }
+  if (passwordFlag) {
+    password = decoder.getByteArray();
+  }
 
-    decoder.done();
-    if (!willFlag && (willQoS !== 0 || willRetain === true)) {
-      throw new DecoderError(
-        "Will QoS must be 0 and Will retain to false when Will flag is false",
-      );
-    }
+  decoder.done();
+  if (!willFlag && (willQoS !== 0 || willRetain === true)) {
+    throw new DecoderError(
+      "Will QoS must be 0 and Will retain to false when Will flag is false",
+    );
+  }
 
-    if (clientId.length === 0 && cleanSession === false) {
-      throw new DecoderError("Clean session must be true if clientID is empty");
-    }
+  if (clientId.length === 0 && cleanSession === false) {
+    throw new DecoderError("Clean session must be true if clientID is empty");
+  }
 
-    let bridgeModeProp = {};
-    if (bridgeMode) {
-      bridgeModeProp = { bridgeMode };
-    }
-    const commonProps = {
-      type: PacketType.connect,
-      protocolName: protocolName,
-      clientId: clientId,
-      username,
-      password: password ? password : undefined,
-      clean: cleanSession,
-      keepAlive,
-      ...bridgeModeProp,
-    };
+  let bridgeModeProp = {};
+  if (bridgeMode) {
+    bridgeModeProp = { bridgeMode };
+  }
+  const commonProps = {
+    type: PacketType.connect,
+    protocolName: protocolName,
+    clientId: clientId,
+    username,
+    password: password ? password : undefined,
+    clean: cleanSession,
+    keepAlive,
+    ...bridgeModeProp,
+  };
 
-    if (isV5) {
-      return {
-        ...commonProps,
-        protocolLevel: 5,
-        will: willFlag
-          ? {
-            topic: willTopic || "",
-            payload: willPayload || Uint8Array.from([0]),
-            retain: willRetain,
-            qos: willQoS,
-            properties: willProperties,
-          }
-          : undefined,
-        properties,
-      };
-    }
+  if (isV5) {
     return {
       ...commonProps,
-      protocolLevel: protocolLevel as ProtocolLevel,
+      protocolLevel: 5,
       will: willFlag
         ? {
           topic: willTopic || "",
           payload: willPayload || Uint8Array.from([0]),
           retain: willRetain,
           qos: willQoS,
+          properties: willProperties,
         }
         : undefined,
+      properties,
     };
-  },
-};
+  }
+  return {
+    ...commonProps,
+    protocolLevel: protocolLevel as ProtocolLevel,
+    will: willFlag
+      ? {
+        topic: willTopic || "",
+        payload: willPayload || Uint8Array.from([0]),
+        retain: willRetain,
+        qos: willQoS,
+      }
+      : undefined,
+  };
+}

--- a/mqttPacket/disconnect.ts
+++ b/mqttPacket/disconnect.ts
@@ -30,71 +30,64 @@ export type DisconnectPacket = DisconnectPacketv4 | DisconnectPacketv5;
 
 const DISCONNECT_PACKET = new Uint8Array([PacketType.disconnect << 4, 0]);
 
-export const disconnect: {
-  encode(_packet: DisconnectPacket, _codecOpts: CodecOpts): Uint8Array;
-  decode(
-    buffer: Uint8Array,
-    _flags: number,
-    codecOpts: CodecOpts,
-    packetType: TPacketType,
-  ): DisconnectPacket;
-} = {
-  encode(packet: DisconnectPacket, codecOpts: CodecOpts): Uint8Array {
-    if (packet.protocolLevel !== 5) {
-      return DISCONNECT_PACKET;
-    }
-    const reasonCode = packet.reasonCode || ReasonCode.normalDisconnection;
-    const encoder = new Encoder(packet.type);
-    // see MQTT v5 3.14.2.1
-    // if remaining length is less than 1 the value of 0x00 (normal disconnect) is used.
-    if (
-      reasonCode === ReasonCode.normalDisconnection &&
-      Object.keys(packet.properties || {}).length === 0
-    ) {
-      return encoder.done(0);
-    }
-    encoder
-      .setReasonCode(reasonCode);
-    if (packet.properties) {
-      encoder.setProperties(
-        packet.properties,
-        packet.type,
-        codecOpts.maxOutgoingPacketSize,
-      );
-    }
+export function encode(
+  packet: DisconnectPacket,
+  codecOpts: CodecOpts,
+): Uint8Array {
+  if (packet.protocolLevel !== 5) {
+    return DISCONNECT_PACKET;
+  }
+  const reasonCode = packet.reasonCode || ReasonCode.normalDisconnection;
+  const encoder = new Encoder(packet.type);
+  // see MQTT v5 3.14.2.1
+  // if remaining length is less than 1 the value of 0x00 (normal disconnect) is used.
+  if (
+    reasonCode === ReasonCode.normalDisconnection &&
+    Object.keys(packet.properties || {}).length === 0
+  ) {
     return encoder.done(0);
-  },
+  }
+  encoder
+    .setReasonCode(reasonCode);
+  if (packet.properties) {
+    encoder.setProperties(
+      packet.properties,
+      packet.type,
+      codecOpts.maxOutgoingPacketSize,
+    );
+  }
+  return encoder.done(0);
+}
 
-  decode(
-    buffer: Uint8Array,
-    flags: number,
-    codecOpts,
-    packetType: TPacketType,
-  ): DisconnectPacket {
-    hasEmptyFlags(flags);
-    if (codecOpts.protocolLevel !== 5) {
-      isEmptyBuf(buffer);
-      return {
-        type: PacketType.disconnect,
-        protocolLevel: codecOpts.protocolLevel,
-      };
-    }
-    const decoder = new Decoder(packetType, buffer);
-    if (decoder.atEnd()) {
-      return {
-        type: PacketType.disconnect,
-        protocolLevel: 5,
-        reasonCode: 0,
-      };
-    }
-    const reasonCode = decoder.getReasonCode();
-    const properties = decoder.getProperties(PacketType.disconnect);
-    decoder.done();
+export function decode(
+  buffer: Uint8Array,
+  flags: number,
+  codecOpts: CodecOpts,
+  packetType: TPacketType,
+): DisconnectPacket {
+  hasEmptyFlags(flags);
+  if (codecOpts.protocolLevel !== 5) {
+    isEmptyBuf(buffer);
+    return {
+      type: PacketType.disconnect,
+      protocolLevel: codecOpts.protocolLevel,
+    };
+  }
+  const decoder = new Decoder(packetType, buffer);
+  if (decoder.atEnd()) {
     return {
       type: PacketType.disconnect,
       protocolLevel: 5,
-      reasonCode,
-      properties,
+      reasonCode: 0,
     };
-  },
-};
+  }
+  const reasonCode = decoder.getReasonCode();
+  const properties = decoder.getProperties(PacketType.disconnect);
+  decoder.done();
+  return {
+    type: PacketType.disconnect,
+    protocolLevel: 5,
+    reasonCode,
+    properties,
+  };
+}

--- a/mqttPacket/mod.ts
+++ b/mqttPacket/mod.ts
@@ -29,22 +29,22 @@ export { ReasonCode, ReasonCodeByNumber } from "./ReasonCode.ts";
 import { PacketNameByType, PacketType } from "./PacketType.ts";
 import { invalidTopic, invalidTopicFilter, invalidUTF8 } from "./validators.ts";
 import { decodeLength, encodeLength } from "./length.ts";
-import { connect } from "./connect.ts";
-import { connack } from "./connack.ts";
+import * as connect from "./connect.ts";
+import * as connack from "./connack.ts";
 import {
   AuthenticationResult,
   AuthenticationResultByNumber,
 } from "./AuthenticationResult.ts";
-import { publish } from "./publish.ts";
-import { anyAck } from "./pubblishAcks.ts";
-import { subscribe } from "./subscribe.ts";
-import { suback } from "./suback.ts";
-import { unsubscribe } from "./unsubscribe.ts";
-import { unsuback } from "./unsuback.ts";
-import { pingreq } from "./pingreq.ts";
-import { pingres } from "./pingres.ts";
-import { disconnect } from "./disconnect.ts";
-import { auth } from "./auth.ts";
+import * as publish from "./publish.ts";
+import * as anyAck from "./pubblishAcks.ts";
+import * as subscribe from "./subscribe.ts";
+import * as suback from "./suback.ts";
+import * as unsubscribe from "./unsubscribe.ts";
+import * as unsuback from "./unsuback.ts";
+import * as pingreq from "./pingreq.ts";
+import * as pingres from "./pingres.ts";
+import * as disconnect from "./disconnect.ts";
+import * as auth from "./auth.ts";
 import { DecoderError } from "./decoder.ts";
 
 import type { ConnectPacket } from "./connect.ts";

--- a/mqttPacket/pingreq.ts
+++ b/mqttPacket/pingreq.ts
@@ -12,30 +12,23 @@ export type PingreqPacket = {
 
 const PINGRES_PACKET = new Uint8Array([PacketType.pingreq << 4, 0]);
 
-export const pingreq: {
-  encode(_packet: PingreqPacket, _codecOpts: CodecOpts): Uint8Array;
-  decode(
-    buffer: Uint8Array,
-    flags: number,
-    codecOpts: CodecOpts,
-    _packetType: TPacketType,
-  ): PingreqPacket;
-} = {
-  encode(_packet: PingreqPacket, _codecOpts: CodecOpts): Uint8Array {
-    return PINGRES_PACKET;
-  },
+export function encode(
+  _packet: PingreqPacket,
+  _codecOpts: CodecOpts,
+): Uint8Array {
+  return PINGRES_PACKET;
+}
 
-  decode(
-    buffer: Uint8Array,
-    flags: number,
-    codecOpts: CodecOpts,
-    _packetType: TPacketType,
-  ): PingreqPacket {
-    hasEmptyFlags(flags);
-    isEmptyBuf(buffer);
-    return {
-      type: PacketType.pingreq,
-      protocolLevel: codecOpts.protocolLevel,
-    };
-  },
-};
+export function decode(
+  buffer: Uint8Array,
+  flags: number,
+  codecOpts: CodecOpts,
+  _packetType: TPacketType,
+): PingreqPacket {
+  hasEmptyFlags(flags);
+  isEmptyBuf(buffer);
+  return {
+    type: PacketType.pingreq,
+    protocolLevel: codecOpts.protocolLevel,
+  };
+}

--- a/mqttPacket/pingres.ts
+++ b/mqttPacket/pingres.ts
@@ -13,30 +13,23 @@ export type PingresPacket = {
 
 const PINGRES_PACKET = new Uint8Array([PacketType.pingres << 4, 0]);
 
-export const pingres: {
-  encode(packet: PingresPacket, _codecOpts: CodecOpts): Uint8Array;
-  decode(
-    buffer: Uint8Array,
-    flags: number,
-    codecOpts: CodecOpts,
-    _packetType: TPacketType,
-  ): PingresPacket;
-} = {
-  encode(_packet: PingresPacket, _codecOpts: CodecOpts): Uint8Array {
-    return PINGRES_PACKET;
-  },
+export function encode(
+  _packet: PingresPacket,
+  _codecOpts: CodecOpts,
+): Uint8Array {
+  return PINGRES_PACKET;
+}
 
-  decode(
-    buffer: Uint8Array,
-    flags: number,
-    codecOpts: CodecOpts,
-    _packetType: TPacketType,
-  ): PingresPacket {
-    hasEmptyFlags(flags);
-    isEmptyBuf(buffer);
-    return {
-      type: PacketType.pingres,
-      protocolLevel: codecOpts.protocolLevel,
-    };
-  },
-};
+export function decode(
+  buffer: Uint8Array,
+  flags: number,
+  codecOpts: CodecOpts,
+  _packetType: TPacketType,
+): PingresPacket {
+  hasEmptyFlags(flags);
+  isEmptyBuf(buffer);
+  return {
+    type: PacketType.pingres,
+    protocolLevel: codecOpts.protocolLevel,
+  };
+}

--- a/mqttPacket/pubblishAcks.ts
+++ b/mqttPacket/pubblishAcks.ts
@@ -55,74 +55,64 @@ export type AnyAckPacket =
   | PubrelPacket
   | PubcompPacket;
 
-export const anyAck: {
-  encode(packet: AnyAckPacket, codecOpts: CodecOpts): Uint8Array;
-  decode(
-    buffer: Uint8Array,
-    flags: number,
-    codecOpts: CodecOpts,
-    packetType: TPacketType,
-  ): AnyAckPacket;
-} = {
-  encode(packet: AnyAckPacket, codecOpts: CodecOpts): Uint8Array {
-    const flags = packet.type === PacketType.pubrel ? 2 : 0;
-    const encoder = new Encoder(packet.type);
-    encoder.setInt16(packet.id);
-    if (packet.protocolLevel === 5) {
-      const reasonCode = packet.reasonCode || ReasonCode.success;
-      // if remaining length is less than 1 the value of 0x00 (success) is used.
-      if (
-        reasonCode === ReasonCode.success &&
-        Object.keys(packet.properties || {}).length === 0
-      ) {
-        return encoder.done(flags);
-      }
-      encoder.setReasonCode(reasonCode);
-      encoder.setProperties(
-        packet.properties || {},
-        packet.type,
-        codecOpts.maxOutgoingPacketSize,
-      );
+export function encode(packet: AnyAckPacket, codecOpts: CodecOpts): Uint8Array {
+  const flags = packet.type === PacketType.pubrel ? 2 : 0;
+  const encoder = new Encoder(packet.type);
+  encoder.setInt16(packet.id);
+  if (packet.protocolLevel === 5) {
+    const reasonCode = packet.reasonCode || ReasonCode.success;
+    // if remaining length is less than 1 the value of 0x00 (success) is used.
+    if (
+      reasonCode === ReasonCode.success &&
+      Object.keys(packet.properties || {}).length === 0
+    ) {
+      return encoder.done(flags);
     }
-    return encoder.done(flags);
-  },
+    encoder.setReasonCode(reasonCode);
+    encoder.setProperties(
+      packet.properties || {},
+      packet.type,
+      codecOpts.maxOutgoingPacketSize,
+    );
+  }
+  return encoder.done(flags);
+}
 
-  decode(
-    buffer: Uint8Array,
-    flags: number,
-    codecOpts: CodecOpts,
-    packetType: TPacketType,
-  ): AnyAckPacket {
-    const expectedFlags = packetType === PacketType.pubrel ? 2 : 0;
-    if (flags !== expectedFlags) {
-      throw new DecoderError("Invalid flags");
-    }
-    const decoder = new Decoder(packetType, buffer);
-    const id = decoder.getInt16();
-    if (codecOpts.protocolLevel !== 5) {
-      decoder.done();
-      return {
-        type: packetType as AnyAckPacket["type"],
-        protocolLevel: codecOpts.protocolLevel,
-        id,
-      } as AnyAckPacket;
-    }
-    if (decoder.atEnd()) {
-      return {
-        type: packetType as AnyAckPacket["type"],
-        protocolLevel: 5,
-        id,
-        reasonCode: 0,
-      } as AnyAckPacket;
-    }
-    const reasonCode = decoder.getReasonCode();
-    const properties = decoder.getProperties(packetType);
+export function decode(
+  buffer: Uint8Array,
+  flags: number,
+  codecOpts: CodecOpts,
+  packetType: TPacketType,
+): AnyAckPacket {
+  const expectedFlags = packetType === PacketType.pubrel ? 2 : 0;
+  if (flags !== expectedFlags) {
+    throw new DecoderError("Invalid flags");
+  }
+  const decoder = new Decoder(packetType, buffer);
+  const id = decoder.getInt16();
+  if (codecOpts.protocolLevel !== 5) {
+    decoder.done();
+    return {
+      type: packetType as AnyAckPacket["type"],
+      protocolLevel: codecOpts.protocolLevel,
+      id,
+    } as AnyAckPacket;
+  }
+  if (decoder.atEnd()) {
     return {
       type: packetType as AnyAckPacket["type"],
       protocolLevel: 5,
       id,
-      reasonCode,
-      properties,
+      reasonCode: 0,
     } as AnyAckPacket;
-  },
-};
+  }
+  const reasonCode = decoder.getReasonCode();
+  const properties = decoder.getProperties(packetType);
+  return {
+    type: packetType as AnyAckPacket["type"],
+    protocolLevel: 5,
+    id,
+    reasonCode,
+    properties,
+  } as AnyAckPacket;
+}

--- a/mqttPacket/publish.ts
+++ b/mqttPacket/publish.ts
@@ -41,89 +41,70 @@ export type PublishPacketV5 = {
 /** Publish packet (v4|v5). */
 export type PublishPacket = PublishPacketV4 | PublishPacketV5;
 
-export const publish: {
-  encode(packet: PublishPacket, _codecOpts: CodecOpts): Uint8Array;
-  decode(
-    buffer: Uint8Array,
-    flags: number,
-    codecOpts: CodecOpts,
-    packetType: TPacketType,
-  ): PublishPacket;
-} = {
-  encode(packet: PublishPacket, codecOpts: CodecOpts): Uint8Array {
-    const qos = packet.qos || 0;
+export function encode(
+  packet: PublishPacket,
+  codecOpts: CodecOpts,
+): Uint8Array {
+  const qos = packet.qos || 0;
 
-    const flags = (packet.dup ? BitMask.bit3 : 0) +
-      (qos & 2 ? BitMask.bit2 : 0) +
-      (qos & 1 ? BitMask.bit1 : 0) +
-      (packet.retain ? BitMask.bit0 : 0);
+  const flags = (packet.dup ? BitMask.bit3 : 0) +
+    (qos & 2 ? BitMask.bit2 : 0) +
+    (qos & 1 ? BitMask.bit1 : 0) +
+    (packet.retain ? BitMask.bit0 : 0);
 
-    const encoder = new Encoder(packet.type);
-    encoder.setTopic(packet.topic);
+  const encoder = new Encoder(packet.type);
+  encoder.setTopic(packet.topic);
 
-    if (qos === 1 || qos === 2) {
-      if (typeof packet.id !== "number" || packet.id < 1) {
-        throw new EncoderError("when qos is 1 or 2, packet must have id");
-      }
-      encoder.setInt16(packet.id);
+  if (qos === 1 || qos === 2) {
+    if (typeof packet.id !== "number" || packet.id < 1) {
+      throw new EncoderError("when qos is 1 or 2, packet must have id");
     }
+    encoder.setInt16(packet.id);
+  }
 
-    if (packet.protocolLevel === 5) {
-      encoder.setProperties(
-        packet.properties || {},
-        PacketType.publish,
-        codecOpts.maxOutgoingPacketSize,
-      );
-    }
-    encoder.setRemainder(packet.payload);
-    return encoder.done(flags);
-  },
+  if (packet.protocolLevel === 5) {
+    encoder.setProperties(
+      packet.properties || {},
+      PacketType.publish,
+      codecOpts.maxOutgoingPacketSize,
+    );
+  }
+  encoder.setRemainder(packet.payload);
+  return encoder.done(flags);
+}
 
-  decode(
-    buffer: Uint8Array,
-    flags: number,
-    codecOpts: CodecOpts,
-    packetType: TPacketType,
-  ): PublishPacket {
-    const dup = booleanFlag(flags, BitMask.bit3);
-    const qos = (flags & 6) >> 1;
-    const retain = booleanFlag(flags, BitMask.bit0);
+export function decode(
+  buffer: Uint8Array,
+  flags: number,
+  codecOpts: CodecOpts,
+  packetType: TPacketType,
+): PublishPacket {
+  const dup = booleanFlag(flags, BitMask.bit3);
+  const qos = (flags & 6) >> 1;
+  const retain = booleanFlag(flags, BitMask.bit0);
 
-    if (qos !== 0 && qos !== 1 && qos !== 2) {
-      throw new DecoderError("Invalid qos");
-    }
+  if (qos !== 0 && qos !== 1 && qos !== 2) {
+    throw new DecoderError("Invalid qos");
+  }
 
-    if (dup && qos === 0) {
-      throw new DecoderError("Invalid qos for possible duplicate");
-    }
+  if (dup && qos === 0) {
+    throw new DecoderError("Invalid qos for possible duplicate");
+  }
 
-    const decoder = new Decoder(packetType, buffer);
-    const topic = decoder.getTopic();
+  const decoder = new Decoder(packetType, buffer);
+  const topic = decoder.getTopic();
 
-    let id = undefined;
-    if (qos > 0) {
-      id = decoder.getInt16();
-    }
-    if (codecOpts.protocolLevel === 5) {
-      const properties = decoder.getProperties(PacketType.publish);
-      const payload = decoder.getRemainder();
-      return {
-        type: PacketType.publish,
-        protocolLevel: 5,
-        properties,
-        topic,
-        payload,
-        dup,
-        retain,
-        qos,
-        id,
-      };
-    }
-    // no decoder.done() required because of getRemainder
+  let id = undefined;
+  if (qos > 0) {
+    id = decoder.getInt16();
+  }
+  if (codecOpts.protocolLevel === 5) {
+    const properties = decoder.getProperties(PacketType.publish);
     const payload = decoder.getRemainder();
     return {
       type: PacketType.publish,
-      protocolLevel: codecOpts.protocolLevel,
+      protocolLevel: 5,
+      properties,
       topic,
       payload,
       dup,
@@ -131,5 +112,17 @@ export const publish: {
       qos,
       id,
     };
-  },
-};
+  }
+  // no decoder.done() required because of getRemainder
+  const payload = decoder.getRemainder();
+  return {
+    type: PacketType.publish,
+    protocolLevel: codecOpts.protocolLevel,
+    topic,
+    payload,
+    dup,
+    retain,
+    qos,
+    id,
+  };
+}

--- a/mqttPacket/suback.ts
+++ b/mqttPacket/suback.ts
@@ -33,68 +33,58 @@ export type SubackPacketV5 = {
  */
 export type SubackPacket = SubackPacketV4 | SubackPacketV5;
 
-export const suback: {
-  encode(packet: SubackPacket, _codecOpts: CodecOpts): Uint8Array;
-  decode(
-    buffer: Uint8Array,
-    flags: number,
-    codecOpts: CodecOpts,
-    packetType: TPacketType,
-  ): SubackPacket;
-} = {
-  encode(packet: SubackPacket, codecOpts: CodecOpts): Uint8Array {
-    const flags = 0;
-    const encoder = new Encoder(packet.type);
-    encoder.setInt16(packet.id);
-    if (packet.protocolLevel !== 5) {
-      for (const code of packet.returnCodes) {
-        if (!validReturnCodes.includes(code)) {
-          throw new Error("Invalid return code");
-        }
+export function encode(packet: SubackPacket, codecOpts: CodecOpts): Uint8Array {
+  const flags = 0;
+  const encoder = new Encoder(packet.type);
+  encoder.setInt16(packet.id);
+  if (packet.protocolLevel !== 5) {
+    for (const code of packet.returnCodes) {
+      if (!validReturnCodes.includes(code)) {
+        throw new Error("Invalid return code");
       }
-      encoder.setRemainder(packet.returnCodes);
-      return encoder.done(flags);
     }
-    encoder.setProperties(
-      packet.properties || {},
-      packet.type,
-      codecOpts.maxOutgoingPacketSize,
-    );
-    for (const code of packet.reasonCodes) {
-      encoder.setReasonCode(code);
-    }
+    encoder.setRemainder(packet.returnCodes);
     return encoder.done(flags);
-  },
+  }
+  encoder.setProperties(
+    packet.properties || {},
+    packet.type,
+    codecOpts.maxOutgoingPacketSize,
+  );
+  for (const code of packet.reasonCodes) {
+    encoder.setReasonCode(code);
+  }
+  return encoder.done(flags);
+}
 
-  decode(
-    buffer: Uint8Array,
-    _flags: number,
-    codecOpts: CodecOpts,
-    packetType: TPacketType,
-  ): SubackPacket {
-    const packet = {} as SubackPacket;
-    const decoder = new Decoder(packetType, buffer);
-    packet.type = PacketType.suback;
-    packet.id = decoder.getInt16();
-    packet.protocolLevel = codecOpts.protocolLevel;
+export function decode(
+  buffer: Uint8Array,
+  _flags: number,
+  codecOpts: CodecOpts,
+  packetType: TPacketType,
+): SubackPacket {
+  const packet = {} as SubackPacket;
+  const decoder = new Decoder(packetType, buffer);
+  packet.type = PacketType.suback;
+  packet.id = decoder.getInt16();
+  packet.protocolLevel = codecOpts.protocolLevel;
 
-    if (packet.protocolLevel !== 5) {
-      const payload = decoder.getRemainder();
-      packet.returnCodes = [];
-      for (const code of payload) {
-        if (!validReturnCodes.includes(code)) {
-          throw new DecoderError("Invalid return code");
-        }
-        packet.returnCodes.push(code);
+  if (packet.protocolLevel !== 5) {
+    const payload = decoder.getRemainder();
+    packet.returnCodes = [];
+    for (const code of payload) {
+      if (!validReturnCodes.includes(code)) {
+        throw new DecoderError("Invalid return code");
       }
-      return packet;
-    }
-    packet.properties = decoder.getProperties(PacketType.suback);
-    packet.reasonCodes = [];
-    while (!decoder.atEnd()) {
-      const code = decoder.getReasonCode();
-      packet.reasonCodes.push(code);
+      packet.returnCodes.push(code);
     }
     return packet;
-  },
-};
+  }
+  packet.properties = decoder.getProperties(PacketType.suback);
+  packet.reasonCodes = [];
+  while (!decoder.atEnd()) {
+    const code = decoder.getReasonCode();
+    packet.reasonCodes.push(code);
+  }
+  return packet;
+}

--- a/mqttPacket/subscribe.ts
+++ b/mqttPacket/subscribe.ts
@@ -81,146 +81,125 @@ export type Subscription = SubscriptionV4 | SubscriptionV5;
 /**
  * Codec utility object responsible for encoding and decoding MQTT SUBSCRIBE control packets.
  */
-export const subscribe: {
-  /**
-   * Serializes a SubscribePacket into an MQTT compliant binary buffer.
-   * @param {SubscribePacket} packet - The subscribe packet model to encode.
-   * @param {CodecOpts} codecOpts - The configuration options regulating serialization limits.
-   * @returns {Uint8Array} The fully encoded binary payload.
-   */
-  encode(packet: SubscribePacket, codecOpts: CodecOpts): Uint8Array;
-  /**
-   * Deserializes a binary payload into a structured SubscribePacket instance.
-   * @param {Uint8Array} buffer - The binary buffer slice containing the packet.
-   * @param {number} flags - The exact configuration flags parsed from the fixed header.
-   * @param {CodecOpts} codecOpts - Configuration properties outlining the contextual protocol parser levels.
-   * @param {TPacketType} packetType - The explicit control packet identifier byte.
-   * @returns {SubscribePacket} A parsed instance of SubscribePacket V4 or V5.
-   */
-  decode(
-    buffer: Uint8Array,
-    flags: number,
-    codecOpts: CodecOpts,
-    packetType: TPacketType,
-  ): SubscribePacket;
-} = {
-  encode(packet: SubscribePacket, codecOpts: CodecOpts): Uint8Array {
-    // Bits 3,2,1 and 0 of the fixed header of the SUBSCRIBE Control Packet are reserved and
-    // MUST be set to 0,0,1 and 0 respectively. The Server MUST treat any other value as
-    // malformed and close the Network Connection [MQTT-3.8.1-1].
-    const flags = 0b0010;
+export function encode(
+  packet: SubscribePacket,
+  codecOpts: CodecOpts,
+): Uint8Array {
+  // Bits 3,2,1 and 0 of the fixed header of the SUBSCRIBE Control Packet are reserved and
+  // MUST be set to 0,0,1 and 0 respectively. The Server MUST treat any other value as
+  // malformed and close the Network Connection [MQTT-3.8.1-1].
+  const flags = 0b0010;
 
-    const encoder = new Encoder(packet.type);
-    encoder.setInt16(packet.id);
+  const encoder = new Encoder(packet.type);
+  encoder.setInt16(packet.id);
+  if (packet.protocolLevel === 5) {
+    encoder.setProperties(
+      packet.properties || {},
+      packet.type,
+      codecOpts.maxOutgoingPacketSize,
+    );
+  }
+  for (const sub of packet.subscriptions) {
+    encoder.setTopicFilter(sub.topicFilter);
     if (packet.protocolLevel === 5) {
-      encoder.setProperties(
-        packet.properties || {},
-        packet.type,
-        codecOpts.maxOutgoingPacketSize,
-      );
+      const {
+        qos,
+        noLocal = false,
+        retainAsPublished = false,
+        retainHandling = 0,
+      } = sub as SubscriptionV5;
+      const option = (qos & 1 ? BitMask.bit0 : 0) +
+        (qos & 2 ? BitMask.bit1 : 0) +
+        (noLocal ? BitMask.bit2 : 0) +
+        (retainAsPublished ? BitMask.bit3 : 0) +
+        ((retainHandling as number) & 1 ? BitMask.bit4 : 0) +
+        ((retainHandling as number) & 2 ? BitMask.bit5 : 0);
+      encoder.setByte(option);
+    } else {
+      encoder.setByte(sub.qos);
     }
-    for (const sub of packet.subscriptions) {
-      encoder.setTopicFilter(sub.topicFilter);
-      if (packet.protocolLevel === 5) {
-        const {
-          qos,
-          noLocal = false,
-          retainAsPublished = false,
-          retainHandling = 0,
-        } = sub as SubscriptionV5;
-        const option = (qos & 1 ? BitMask.bit0 : 0) +
-          (qos & 2 ? BitMask.bit1 : 0) +
-          (noLocal ? BitMask.bit2 : 0) +
-          (retainAsPublished ? BitMask.bit3 : 0) +
-          ((retainHandling as number) & 1 ? BitMask.bit4 : 0) +
-          ((retainHandling as number) & 2 ? BitMask.bit5 : 0);
-        encoder.setByte(option);
-      } else {
-        encoder.setByte(sub.qos);
-      }
-    }
-    return encoder.done(flags);
-  },
+  }
+  return encoder.done(flags);
+}
 
-  decode(
-    buffer: Uint8Array,
-    flags: number,
-    codecOpts: CodecOpts,
-    packetType: TPacketType,
-  ): SubscribePacket {
-    // Bits 3,2,1 and 0 of the fixed header of the SUBSCRIBE Control Packet are reserved and
-    // MUST be set to 0,0,1 and 0 respectively. The Server MUST treat any other value as
-    // malformed and close the Network Connection [MQTT-3.8.1-1].
-    if (flags !== 0b0010) {
-      throw new DecoderError("Invalid header");
-    }
-    const decoder = new Decoder(packetType, buffer);
-    const id = decoder.getInt16();
-    let properties = {};
-    if (codecOpts.protocolLevel === 5) {
-      properties = decoder.getProperties(PacketType.subscribe);
-    }
+export function decode(
+  buffer: Uint8Array,
+  flags: number,
+  codecOpts: CodecOpts,
+  packetType: TPacketType,
+): SubscribePacket {
+  // Bits 3,2,1 and 0 of the fixed header of the SUBSCRIBE Control Packet are reserved and
+  // MUST be set to 0,0,1 and 0 respectively. The Server MUST treat any other value as
+  // malformed and close the Network Connection [MQTT-3.8.1-1].
+  if (flags !== 0b0010) {
+    throw new DecoderError("Invalid header");
+  }
+  const decoder = new Decoder(packetType, buffer);
+  const id = decoder.getInt16();
+  let properties = {};
+  if (codecOpts.protocolLevel === 5) {
+    properties = decoder.getProperties(PacketType.subscribe);
+  }
 
-    const subscriptions: Subscription[] = [];
-    // The payload of a SUBSCRIBE packet MUST contain at least one Topic Filter / Option pair.
-    // A SUBSCRIBE packet with no payload is a protocol violation [MQTT-3.8.3-3].
-    do {
-      const topicFilter = decoder.getTopicFilter();
-      const option = decoder.getByte();
-      const qos = option & 0b11;
-      if (qos !== 0 && qos !== 1 && qos !== 2) {
+  const subscriptions: Subscription[] = [];
+  // The payload of a SUBSCRIBE packet MUST contain at least one Topic Filter / Option pair.
+  // A SUBSCRIBE packet with no payload is a protocol violation [MQTT-3.8.3-3].
+  do {
+    const topicFilter = decoder.getTopicFilter();
+    const option = decoder.getByte();
+    const qos = option & 0b11;
+    if (qos !== 0 && qos !== 1 && qos !== 2) {
+      throw new DecoderError("Invalid qos");
+    }
+    if (qos > 0 && id === 0) {
+      throw new DecoderError("Invalid packet identifier");
+    }
+    if (codecOpts.protocolLevel !== 5) {
+      if (option !== qos) {
         throw new DecoderError("Invalid qos");
       }
-      if (qos > 0 && id === 0) {
-        throw new DecoderError("Invalid packet identifier");
+      subscriptions.push({
+        topicFilter: topicFilter,
+        qos,
+      } as SubscriptionV4);
+    } else {
+      // Bits 6 and 7 of the Subscription Options byte are reserved for future use.
+      // The Server MUST treat a SUBSCRIBE packet as malformed if any of
+      // Reserved bits in the Payload are non-zero [MQTT-3.8.3-5].
+      if (option > 0b111111) {
+        throw new DecoderError("Invalid subscription options");
       }
-      if (codecOpts.protocolLevel !== 5) {
-        if (option !== qos) {
-          throw new DecoderError("Invalid qos");
-        }
-        subscriptions.push({
-          topicFilter: topicFilter,
-          qos,
-        } as SubscriptionV4);
-      } else {
-        // Bits 6 and 7 of the Subscription Options byte are reserved for future use.
-        // The Server MUST treat a SUBSCRIBE packet as malformed if any of
-        // Reserved bits in the Payload are non-zero [MQTT-3.8.3-5].
-        if (option > 0b111111) {
-          throw new DecoderError("Invalid subscription options");
-        }
-        const noLocal = booleanFlag(option, BitMask.bit2);
-        const retainAsPublished = booleanFlag(option, BitMask.bit3);
-        const retainHandling = (option & 0b110000) >> 4;
-        if (
-          retainHandling !== 0 && retainHandling !== 1 && retainHandling !== 2
-        ) {
-          throw new DecoderError("Invalid retain handling");
-        }
-        subscriptions.push({
-          topicFilter: topicFilter,
-          qos,
-          noLocal,
-          retainAsPublished,
-          retainHandling,
-        } as SubscriptionV5);
+      const noLocal = booleanFlag(option, BitMask.bit2);
+      const retainAsPublished = booleanFlag(option, BitMask.bit3);
+      const retainHandling = (option & 0b110000) >> 4;
+      if (
+        retainHandling !== 0 && retainHandling !== 1 && retainHandling !== 2
+      ) {
+        throw new DecoderError("Invalid retain handling");
       }
-    } while (!decoder.atEnd());
-    decoder.done();
-    if (codecOpts.protocolLevel !== 5) {
-      return {
-        type: PacketType.subscribe,
-        protocolLevel: codecOpts.protocolLevel,
-        id,
-        subscriptions: subscriptions as Array<SubscriptionV4>,
-      };
+      subscriptions.push({
+        topicFilter: topicFilter,
+        qos,
+        noLocal,
+        retainAsPublished,
+        retainHandling,
+      } as SubscriptionV5);
     }
+  } while (!decoder.atEnd());
+  decoder.done();
+  if (codecOpts.protocolLevel !== 5) {
     return {
       type: PacketType.subscribe,
-      protocolLevel: 5,
+      protocolLevel: codecOpts.protocolLevel,
       id,
-      properties,
-      subscriptions: subscriptions as Array<SubscriptionV5>,
+      subscriptions: subscriptions as Array<SubscriptionV4>,
     };
-  },
-};
+  }
+  return {
+    type: PacketType.subscribe,
+    protocolLevel: 5,
+    id,
+    properties,
+    subscriptions: subscriptions as Array<SubscriptionV5>,
+  };
+}

--- a/mqttPacket/unsuback.ts
+++ b/mqttPacket/unsuback.ts
@@ -30,61 +30,54 @@ export type UnsubackPacketV5 = {
  */
 export type UnsubackPacket = UnsubackPacketV4 | UnsubackPacketV5;
 
-export const unsuback: {
-  encode(packet: UnsubackPacket, codecOpts: CodecOpts): Uint8Array;
-  decode(
-    buffer: Uint8Array,
-    flags: number,
-    codecOpts: CodecOpts,
-    packetType: TPacketType,
-  ): UnsubackPacket;
-} = {
-  encode(packet: UnsubackPacket, codecOpts: CodecOpts): Uint8Array {
-    const flags = 0;
-    const encoder = new Encoder(packet.type);
-    encoder.setInt16(packet.id);
-    if (packet.protocolLevel === 5) {
-      encoder.setProperties(
-        packet.properties || {},
-        PacketType.unsuback,
-        codecOpts.maxOutgoingPacketSize,
-      );
-      for (const reasonCode of packet.reasonCodes) {
-        encoder.setByte(reasonCode);
-      }
+export function encode(
+  packet: UnsubackPacket,
+  codecOpts: CodecOpts,
+): Uint8Array {
+  const flags = 0;
+  const encoder = new Encoder(packet.type);
+  encoder.setInt16(packet.id);
+  if (packet.protocolLevel === 5) {
+    encoder.setProperties(
+      packet.properties || {},
+      PacketType.unsuback,
+      codecOpts.maxOutgoingPacketSize,
+    );
+    for (const reasonCode of packet.reasonCodes) {
+      encoder.setByte(reasonCode);
     }
-    return encoder.done(flags);
-  },
+  }
+  return encoder.done(flags);
+}
 
-  decode(
-    buffer: Uint8Array,
-    flags: number,
-    codecOpts: CodecOpts,
-    packetType: TPacketType,
-  ): UnsubackPacket {
-    hasEmptyFlags(flags);
-    const decoder = new Decoder(packetType, buffer);
-    const id = decoder.getInt16();
-    if (codecOpts.protocolLevel === 5) {
-      const properties = decoder.getProperties(PacketType.unsuback);
-      const reasonCodes = [];
-      while (!decoder.atEnd()) {
-        const reasonCode = decoder.getReasonCode();
-        reasonCodes.push(reasonCode);
-      }
-      return {
-        type: PacketType.unsuback,
-        protocolLevel: 5,
-        id,
-        properties,
-        reasonCodes: reasonCodes as Array<TReasonCode>,
-      };
+export function decode(
+  buffer: Uint8Array,
+  flags: number,
+  codecOpts: CodecOpts,
+  packetType: TPacketType,
+): UnsubackPacket {
+  hasEmptyFlags(flags);
+  const decoder = new Decoder(packetType, buffer);
+  const id = decoder.getInt16();
+  if (codecOpts.protocolLevel === 5) {
+    const properties = decoder.getProperties(PacketType.unsuback);
+    const reasonCodes = [];
+    while (!decoder.atEnd()) {
+      const reasonCode = decoder.getReasonCode();
+      reasonCodes.push(reasonCode);
     }
-    decoder.done();
     return {
       type: PacketType.unsuback,
-      protocolLevel: codecOpts.protocolLevel,
+      protocolLevel: 5,
       id,
+      properties,
+      reasonCodes: reasonCodes as Array<TReasonCode>,
     };
-  },
-};
+  }
+  decoder.done();
+  return {
+    type: PacketType.unsuback,
+    protocolLevel: codecOpts.protocolLevel,
+    id,
+  };
+}

--- a/mqttPacket/unsubscribe.ts
+++ b/mqttPacket/unsubscribe.ts
@@ -49,85 +49,64 @@ export type UnsubscribePacket = UnsubscribePacketV4 | UnsubscribePacketV5;
 /**
  * Codec utility object responsible for encoding and decoding MQTT UNSUBSCRIBE control packets.
  */
-export const unsubscribe: {
-  /**
-   * Serializes an UnsubscribePacket into an MQTT compliant binary buffer.
-   * @param {UnsubscribePacket} packet - The unsubscribe packet model to encode.
-   * @param {CodecOpts} codecOpts - The configuration options regulating serialization limits.
-   * @returns {Uint8Array} The fully encoded binary payload.
-   */
-  encode(packet: UnsubscribePacket, codecOpts: CodecOpts): Uint8Array;
-  /**
-   * Deserializes a binary payload into a structured UnsubscribePacket instance.
-   * @param {Uint8Array} buffer - The binary buffer slice containing the packet.
-   * @param {number} flags - The exact configuration flags parsed from the fixed header.
-   * @param {CodecOpts} codecOpts - Configuration properties outlining the contextual protocol parser levels.
-   * @param {TPacketType} packetType - The explicit control packet identifier byte.
-   * @returns {UnsubscribePacket} A parsed instance of UnsubscribePacket V4 or V5.
-   */
-  decode(
-    buffer: Uint8Array,
-    flags: number,
-    codecOpts: CodecOpts,
-    packetType: TPacketType,
-  ): UnsubscribePacket;
-} = {
-  encode(packet: UnsubscribePacket, codecOpts: CodecOpts): Uint8Array {
-    // Bits 3,2,1 and 0 of the fixed header of the UNSUBSCRIBE Control Packet are reserved and
-    // MUST be set to 0,0,1 and 0 respectively. The Server MUST treat any other value as
-    // malformed and close the Network Connection [MQTT-3.10.1-1].
-    const flags = 0b0010;
+export function encode(
+  packet: UnsubscribePacket,
+  codecOpts: CodecOpts,
+): Uint8Array {
+  // Bits 3,2,1 and 0 of the fixed header of the UNSUBSCRIBE Control Packet are reserved and
+  // MUST be set to 0,0,1 and 0 respectively. The Server MUST treat any other value as
+  // malformed and close the Network Connection [MQTT-3.10.1-1].
+  const flags = 0b0010;
 
-    const encoder = new Encoder(packet.type);
-    encoder.setInt16(packet.id);
-    if (packet.protocolLevel === 5) {
-      encoder.setProperties(
-        packet.properties || {},
-        PacketType.unsubscribe,
-        codecOpts.maxOutgoingPacketSize,
-      );
-    }
-    for (const topicFilter of packet.topicFilters) {
-      encoder.setTopicFilter(topicFilter);
-    }
-    return encoder.done(flags);
-  },
+  const encoder = new Encoder(packet.type);
+  encoder.setInt16(packet.id);
+  if (packet.protocolLevel === 5) {
+    encoder.setProperties(
+      packet.properties || {},
+      PacketType.unsubscribe,
+      codecOpts.maxOutgoingPacketSize,
+    );
+  }
+  for (const topicFilter of packet.topicFilters) {
+    encoder.setTopicFilter(topicFilter);
+  }
+  return encoder.done(flags);
+}
 
-  decode(
-    buffer: Uint8Array,
-    flags: number,
-    codecOpts: CodecOpts,
-    packetType: TPacketType,
-  ): UnsubscribePacket {
-    if (flags !== 0b0010) {
-      throw new DecoderError("Invalid header");
-    }
-    const decoder = new Decoder(packetType, buffer);
-    const id = decoder.getInt16();
-    let properties = {};
-    if (codecOpts.protocolLevel === 5) {
-      properties = decoder.getProperties(PacketType.unsubscribe);
-    }
-    const topicFilters: Topic[] = [];
-    do {
-      const topicFilter = decoder.getTopicFilter();
-      topicFilters.push(topicFilter);
-    } while (!decoder.atEnd());
-    decoder.done();
-    if (codecOpts.protocolLevel !== 5) {
-      return {
-        type: PacketType.unsubscribe,
-        protocolLevel: codecOpts.protocolLevel,
-        id,
-        topicFilters,
-      };
-    }
+export function decode(
+  buffer: Uint8Array,
+  flags: number,
+  codecOpts: CodecOpts,
+  packetType: TPacketType,
+): UnsubscribePacket {
+  if (flags !== 0b0010) {
+    throw new DecoderError("Invalid header");
+  }
+  const decoder = new Decoder(packetType, buffer);
+  const id = decoder.getInt16();
+  let properties = {};
+  if (codecOpts.protocolLevel === 5) {
+    properties = decoder.getProperties(PacketType.unsubscribe);
+  }
+  const topicFilters: Topic[] = [];
+  do {
+    const topicFilter = decoder.getTopicFilter();
+    topicFilters.push(topicFilter);
+  } while (!decoder.atEnd());
+  decoder.done();
+  if (codecOpts.protocolLevel !== 5) {
     return {
       type: PacketType.unsubscribe,
-      protocolLevel: 5,
+      protocolLevel: codecOpts.protocolLevel,
       id,
-      properties,
       topicFilters,
     };
-  },
-};
+  }
+  return {
+    type: PacketType.unsubscribe,
+    protocolLevel: 5,
+    id,
+    properties,
+    topicFilters,
+  };
+}


### PR DESCRIPTION
This PR simplifies the typescript exports  for the individual packet encoders/decoders
It makes the code more maintainable and might improve treeshaking.
The general mqttPacket encode/decode interface is unchanged.