### PR TITLE
fix: improve client handling of broker V5 rejects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - chore: move benchmarks to tools folder
 - chore: simplify mqttPacket encoder/decoder exports
 - fix(server): fix empty payload to clear retained message
+- fix(client): fix client handling of broker V5 rejects
 - fix: remove password from demo logging and debug logging
 
 ## [v1.11.3] 31-05-2026

--- a/client/deps.ts
+++ b/client/deps.ts
@@ -31,6 +31,7 @@ export {
   MQTTLevel,
   PacketNameByType,
   PacketType,
+  ReasonCode,
   ReasonCodeByNumber,
 } from "../mqttPacket/mod.ts";
 

--- a/client/handlers/handleDisconnect.test.ts
+++ b/client/handlers/handleDisconnect.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { handleDisconnect } from "./handleDisconnect.ts";
+import { PacketType, ReasonCode, ReasonCodeByNumber } from "../deps.ts";
+import type { DisconnectPacket } from "../deps.ts";
+
+function createMockContext() {
+  return {
+    close: () => {},
+  };
+}
+
+test("handleDisconnect processes V5 rejection", () => {
+  const ctx = createMockContext();
+  const reasonCode = ReasonCode.notAuthorized;
+  assert.throws(() =>
+    handleDisconnect(ctx as never, {
+      type: PacketType.disconnect,
+      protocolLevel: 5,
+      reasonCode,
+    } as DisconnectPacket), Error(ReasonCodeByNumber[reasonCode]));
+});

--- a/client/handlers/handleDisconnect.ts
+++ b/client/handlers/handleDisconnect.ts
@@ -1,0 +1,17 @@
+import type { Context } from "../context.ts";
+import type { DisconnectPacket } from "../deps.ts";
+import { ReasonCodeByNumber } from "../deps.ts";
+
+/**
+ * Handles Disconnect Packet sent by the broker (V5 only)
+ * @param ctx - The MQTT client context
+ * @param packet - The PUBACK packet received from the broker
+ * @description
+ * - throw error
+ */
+export function handleDisconnect(ctx: Context, packet: DisconnectPacket): void {
+  if (packet.protocolLevel === 5 && ((packet.reasonCode ?? 0) !== 0)) {
+    throw new Error(ReasonCodeByNumber[packet.reasonCode!]);
+  }
+  ctx.close();
+}

--- a/client/handlers/handlePacket.ts
+++ b/client/handlers/handlePacket.ts
@@ -8,10 +8,12 @@ import { handlePubrel } from "./handlePubrel.ts";
 import { handlePubcomp } from "./handlePubcomp.ts";
 import { handleSuback } from "./handleSuback.ts";
 import { handleUnsuback } from "./handleUnsuback.ts";
+import { handleDisconnect } from "./handleDisconnect.ts";
 import { logger, PacketNameByType, PacketType } from "../deps.ts";
 import type {
   AnyPacket,
   ConnackPacket,
+  DisconnectPacket,
   PubackPacket,
   PubcompPacket,
   PublishPacket,
@@ -65,6 +67,9 @@ export async function handlePacket(
         break;
       case PacketType.unsuback:
         handleUnsuback(ctx, packet as UnsubackPacket);
+        break;
+      case PacketType.disconnect:
+        handleDisconnect(ctx, packet as DisconnectPacket);
         break;
 
       default:

--- a/client/handlers/handlePuback.test.ts
+++ b/client/handlers/handlePuback.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import { handlePuback } from "./handlePuback.ts";
-import { PacketType } from "../deps.ts";
+import { PacketType, ReasonCode, ReasonCodeByNumber } from "../deps.ts";
 import type { PubackPacket } from "../deps.ts";
 
 function createMockContext() {
@@ -80,4 +80,20 @@ test("handlePuback processes multiple PUBACKs correctly", () => {
   assert.deepStrictEqual(ctx.store.pendingOutgoing.has(2), false);
   assert.deepStrictEqual(ctx.store.pendingOutgoing.has(3), true);
   assert.deepStrictEqual(ctx.receivedIds, [2]);
+});
+
+test("handlePuback processes V5 publish rejection", () => {
+  const ctx = createMockContext();
+  const reasonCode = ReasonCode.notAuthorized;
+  ctx.store.pendingOutgoing.set(2, {
+    type: PacketType.publish,
+    topic: "Test Puback",
+  });
+  assert.throws(() =>
+    handlePuback(ctx as never, {
+      type: PacketType.puback,
+      protocolLevel: 5,
+      id: 2,
+      reasonCode,
+    } as PubackPacket), Error(ReasonCodeByNumber[reasonCode]));
 });

--- a/client/handlers/handlePuback.ts
+++ b/client/handlers/handlePuback.ts
@@ -1,5 +1,6 @@
 import type { Context } from "../context.ts";
 import type { PubackPacket } from "../deps.ts";
+import { ReasonCodeByNumber } from "../deps.ts";
 
 /**
  * Handles PUBACK packet processing for QoS level 1 PUBLISH responses
@@ -12,5 +13,10 @@ import type { PubackPacket } from "../deps.ts";
 export function handlePuback(ctx: Context, packet: PubackPacket): void {
   const id = packet.id;
   ctx.store.pendingOutgoing.delete(id);
+
+  if (packet.protocolLevel === 5 && ((packet.reasonCode ?? 0) !== 0)) {
+    ctx.store.pendingOutgoing.delete(id);
+    throw new Error(ReasonCodeByNumber[packet.reasonCode!]);
+  }
   ctx.receivePuback(id);
 }

--- a/client/handlers/handlePubcomp.test.ts
+++ b/client/handlers/handlePubcomp.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import { handlePubcomp } from "./handlePubcomp.ts";
-import { PacketType } from "../deps.ts";
+import { PacketType, ReasonCode, ReasonCodeByNumber } from "../deps.ts";
 import type { PubcompPacket } from "../deps.ts";
 
 function createMockContext() {
@@ -96,4 +96,17 @@ test("handlePubcomp processes multiple PUBCOMPs correctly", () => {
   assert.deepStrictEqual(ctx.store.pendingAckOutgoing.has(2), false);
   assert.deepStrictEqual(ctx.store.pendingAckOutgoing.has(3), true);
   assert.deepStrictEqual(ctx.receivedIds, [2]);
+});
+
+test("handlePubComp processes V5 rejection", () => {
+  const ctx = createMockContext();
+  ctx.store.pendingAckOutgoing.set(3, { type: PacketType.pubrel, id: 3 });
+  const reasonCode = ReasonCode.notAuthorized;
+  assert.throws(() =>
+    handlePubcomp(ctx as never, {
+      type: PacketType.pubcomp,
+      protocolLevel: 5,
+      id: 3,
+      reasonCode,
+    } as PubcompPacket), Error(ReasonCodeByNumber[reasonCode]));
 });

--- a/client/handlers/handlePubcomp.ts
+++ b/client/handlers/handlePubcomp.ts
@@ -1,5 +1,6 @@
 import type { Context } from "../context.ts";
 import type { PubcompPacket } from "../deps.ts";
+import { ReasonCodeByNumber } from "../deps.ts";
 
 /**
  * Handles PUBCOMP packets which are the response to PUBREL packets in QoS 2 flow
@@ -12,6 +13,10 @@ import type { PubcompPacket } from "../deps.ts";
  */
 export function handlePubcomp(ctx: Context, packet: PubcompPacket): void {
   const id = packet.id;
+  if (packet.protocolLevel === 5 && ((packet.reasonCode ?? 0) !== 0)) {
+    ctx.store.pendingOutgoing.delete(id);
+    throw new Error(ReasonCodeByNumber[packet.reasonCode!]);
+  }
   if (ctx.store.pendingAckOutgoing.has(id)) {
     ctx.store.pendingAckOutgoing.delete(id);
     ctx.receivePubcomp(id);

--- a/client/handlers/handlePubrec.test.ts
+++ b/client/handlers/handlePubrec.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import { handlePubrec } from "./handlePubrec.ts";
-import { PacketType } from "../deps.ts";
+import { PacketType, ReasonCode, ReasonCodeByNumber } from "../deps.ts";
 import type { PubrecPacket } from "../deps.ts";
 
 function createMockContext() {
@@ -100,4 +100,20 @@ test("handlePubrec stores PUBREL packet for retransmission", async () => {
     PacketType.pubrel,
     "Stored packet should be PUBREL",
   );
+});
+
+test("handlePuback processes V5 publish rejection", () => {
+  const ctx = createMockContext();
+  const reasonCode = ReasonCode.notAuthorized;
+  ctx.store.pendingOutgoing.set(2, {
+    type: PacketType.publish,
+    topic: "Test Pubrec",
+  });
+  assert.rejects(() =>
+    handlePubrec(ctx as never, {
+      type: PacketType.pubrec,
+      protocolLevel: 5,
+      id: 2,
+      reasonCode,
+    } as PubrecPacket), Error(ReasonCodeByNumber[reasonCode]));
 });

--- a/client/handlers/handlePubrec.ts
+++ b/client/handlers/handlePubrec.ts
@@ -1,5 +1,5 @@
 import type { Context } from "../context.ts";
-import { PacketType } from "../deps.ts";
+import { PacketType, ReasonCodeByNumber } from "../deps.ts";
 import type { PubrecPacket, PubrelPacket } from "../deps.ts";
 
 /**
@@ -26,6 +26,10 @@ export async function handlePubrec(
     id,
   };
   if (ctx.store.pendingOutgoing.has(id)) {
+    if (packet.protocolLevel === 5 && ((packet.reasonCode ?? 0) !== 0)) {
+      ctx.store.pendingOutgoing.delete(id);
+      throw new Error(ReasonCodeByNumber[packet.reasonCode!]);
+    }
     ctx.store.pendingAckOutgoing.set(id, ack);
     ctx.store.pendingOutgoing.delete(id);
     await ctx.send(ack);

--- a/client/handlers/handleSuback.test.ts
+++ b/client/handlers/handleSuback.test.ts
@@ -95,7 +95,7 @@ test("handleSuback handles subscription failure code", () => {
   );
 });
 
-test("handleSuback skips notification for MQTT v5", () => {
+test("handleSuback handles notification for MQTT v5", () => {
   const ctx = createMockContext();
   ctx.store.pendingOutgoing.set(4, { type: PacketType.subscribe, id: 4 });
 
@@ -108,17 +108,15 @@ test("handleSuback skips notification for MQTT v5", () => {
 
   handleSuback(ctx as never, packet);
 
-  // Should still remove from pending
   assert.deepStrictEqual(
     ctx.store.pendingOutgoing.has(4),
     false,
     "Should remove from pending",
   );
 
-  // But should not call receiveSuback for v5
   assert.deepStrictEqual(
     ctx.receivedSubacks.length,
-    0,
-    "Should not notify for v5 (different flow)",
+    1,
+    "Should notify for v5",
   );
 });

--- a/client/handlers/handleSuback.ts
+++ b/client/handlers/handleSuback.ts
@@ -9,11 +9,14 @@ import type { SubackPacket } from "../deps.ts";
  * - Processes SUBACK packets sent by server to confirm SUBSCRIBE requests
  * - Removes the packet ID from pending outgoing messages
  * - Notifies the client about granted QoS levels for each subscription
+ *    - in V5 the reason codes could carry various errors
  */
 export function handleSuback(ctx: Context, packet: SubackPacket): void {
   const id = packet.id;
   ctx.store.pendingOutgoing.delete(id);
   if (packet.protocolLevel !== 5) {
     ctx.receiveSuback(id, packet.returnCodes);
+    return;
   }
+  ctx.receiveSuback(id, packet.reasonCodes);
 }


### PR DESCRIPTION
This PR adds client side support for receiving Disconnect messages from the broker
It also triggers on V5 failure codes returned by the broker on Publish and Subscribe 